### PR TITLE
Add open check in CSV loader

### DIFF
--- a/src/csv_loader.cpp
+++ b/src/csv_loader.cpp
@@ -2,6 +2,7 @@
 #include <cuda_runtime.h>
 #include <fstream>
 #include <iostream>
+#include <stdexcept>
 #include <sstream>
 
 #define CUDA_CHECK(err)                                                        \
@@ -14,6 +15,10 @@
 
 Table load_csv_to_gpu(const std::string &filepath) {
   std::ifstream file(filepath);
+  if (!file.is_open()) {
+    std::cerr << "Failed to open file: " << filepath << std::endl;
+    throw std::runtime_error("Unable to open file");
+  }
   std::string line;
   std::vector<float> h_price;
   std::vector<int> h_quantity;


### PR DESCRIPTION
## Summary
- ensure csv file is successfully opened before loading data

## Testing
- `cmake ..` *(fails: Failed to find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_683f4e37318c8328a162296178050fdc