### PR TITLE
Fix tokenizer for two-char operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ WarpDB implements a simple recursive descent parser to transform SQL-like expres
 - Numeric literals
 - Binary operations (`+`, `-`, `*`, `/`)
 - Comparison operations (`>`, `<`, `>=`, `<=`, `==`, `!=`)
+  - The tokenizer checks two-character operators (e.g., `>=`, `<=`) before
+    handling single-character ones.
 - Parenthesized expressions
 
 ### JIT Compilation

--- a/src/expression.cpp
+++ b/src/expression.cpp
@@ -24,10 +24,9 @@ std::vector<Token> tokenize(const std::string &input) {
         num += input[i++];
       }
       tokens.push_back({TokenType::Number, num});
-    } else if (std::string("+-*/()<>=!").find(input[i]) != std::string::npos) {
-      tokens.push_back({TokenType::Operator, std::string(1, input[i++])});
     } else if (input[i] == '>' || input[i] == '<' || input[i] == '=' ||
                input[i] == '!') {
+      // Handle two-character comparison operators (>=, <=, ==, !=) first
       std::string op(1, input[i]);
       if (i + 1 < input.size() && input[i + 1] == '=') {
         op += '=';
@@ -35,6 +34,9 @@ std::vector<Token> tokenize(const std::string &input) {
       }
       i++;
       tokens.push_back({TokenType::Operator, op});
+    } else if (std::string("+-*/()<>").find(input[i]) != std::string::npos) {
+      // Remaining single-character operators
+      tokens.push_back({TokenType::Operator, std::string(1, input[i++])});
     } else {
       throw std::runtime_error("Unknown character: " +
                                std::string(1, input[i]));


### PR DESCRIPTION
## Summary
- handle >= <= == and != tokens before single-character operators
- document tokenizer order in README

## Testing
- `cmake ..` *(fails: Failed to find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_683f4e350ae88328af342fce01af3628