### PR TITLE
Add expression parsing validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ CTestTestfile.cmake
 _deps
 CMakeUserPresets.json
 warpdb
+tests/expression_tests

--- a/src/expression.cpp
+++ b/src/expression.cpp
@@ -113,5 +113,9 @@ ASTNodePtr parse_factor() {
 ASTNodePtr parse_expression(const std::vector<Token> &tokens) {
   current = 0;
   toks = tokens;
-  return parse_expression_internal();
+  ASTNodePtr ast = parse_expression_internal();
+  if (peek().type != TokenType::End) {
+    throw std::runtime_error("Unexpected token: " + peek().value);
+  }
+  return ast;
 }

--- a/tests/expression_tests.cpp
+++ b/tests/expression_tests.cpp
@@ -1,0 +1,24 @@
+#include "expression.hpp"
+#include <cassert>
+#include <iostream>
+#include <stdexcept>
+
+void test_malformed_expression() {
+    auto tokens = tokenize("1 2");
+    bool threw = false;
+    try {
+        auto ast = parse_expression(tokens);
+        (void)ast;
+    } catch (const std::runtime_error &e) {
+        threw = true;
+        std::string msg = e.what();
+        assert(msg.find("Unexpected token") != std::string::npos);
+    }
+    assert(threw && "Expected exception for malformed expression");
+}
+
+int main() {
+    test_malformed_expression();
+    std::cout << "All tests passed\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary
- validate there are no extra tokens after parsing an expression
- ignore test binary
- add regression test for invalid expressions

## Testing
- `g++ -std=c++17 tests/expression_tests.cpp src/expression.cpp -Iinclude -o tests/expression_tests && ./tests/expression_tests`

------
https://chatgpt.com/codex/tasks/task_e_6840c29038a083288bcfb934acb8b3b0