### PR TITLE
Fix CUDA toolkit detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ project(WarpDB LANGUAGES CXX CUDA)
 
 set(CMAKE_CXX_STANDARD 17)
 
+find_package(CUDAToolkit REQUIRED)
+
 include_directories(include)
 
 add_executable(warpdb
@@ -17,5 +19,5 @@ set_target_properties(warpdb PROPERTIES
     CUDA_SEPARABLE_COMPILATION ON
 )
 
-target_link_libraries(warpdb PRIVATE /usr/lib/x86_64-linux-gnu/libnvrtc.so cuda)
+target_link_libraries(warpdb PRIVATE CUDA::nvrtc CUDA::cuda_driver)
 

--- a/README.md
+++ b/README.md
@@ -37,12 +37,16 @@ WarpDB consists of the following main components:
 - C++17 compatible compiler
 - NVIDIA GPU with compute capability 7.0 or higher
 
+The build system uses `find_package(CUDAToolkit)` to automatically locate
+NVRTC and the CUDA driver. Ensure the CUDA toolkit is installed and available
+in your environment.
+
 ## Building
 
 ```bash
 mkdir build
 cd build
-cmake ..
+cmake ..  # CMake will locate the CUDA toolkit automatically
 make
 ```
 


### PR DESCRIPTION
## Summary
- use `find_package(CUDAToolkit)` in the build
- link against `CUDA::nvrtc` and `CUDA::cuda_driver`
- mention automatic CUDA toolkit detection in README

## Testing
- `cmake ..` *(fails: Failed to find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6840c28fbdb883288b5192bdd0b11527