### PR TITLE
Add comparison parsing and unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,3 +19,10 @@ set_target_properties(warpdb PROPERTIES
 
 target_link_libraries(warpdb PRIVATE /usr/lib/x86_64-linux-gnu/libnvrtc.so cuda)
 
+add_executable(expression_test
+    tests/test_expression.cpp
+    src/expression.cpp
+)
+
+add_test(NAME expression_test COMMAND expression_test)
+

--- a/src/expression.cpp
+++ b/src/expression.cpp
@@ -78,6 +78,19 @@ ASTNodePtr parse_expression_internal() {
   return node;
 }
 
+// Parses: comparison = add (comp_op add)* where comp_op is >, <, >=, <=, ==, !=
+ASTNodePtr parse_comparison() {
+  ASTNodePtr node = parse_expression_internal();
+  while (match(">") || match("<") || match(">=") || match("<=") ||
+         match("==") || match("!=")) {
+    std::string op = toks[current - 1].value;
+    ASTNodePtr right = parse_expression_internal();
+    node =
+        std::make_unique<BinaryOpNode>(op, std::move(node), std::move(right));
+  }
+  return node;
+}
+
 // Parses: term = factor ( ("*"|"/") factor )*
 ASTNodePtr parse_term() {
   ASTNodePtr node = parse_factor();
@@ -113,5 +126,9 @@ ASTNodePtr parse_factor() {
 ASTNodePtr parse_expression(const std::vector<Token> &tokens) {
   current = 0;
   toks = tokens;
-  return parse_expression_internal();
+  ASTNodePtr node = parse_comparison();
+  if (peek().type != TokenType::End) {
+    throw std::runtime_error("Unexpected tokens remaining: " + peek().value);
+  }
+  return node;
 }

--- a/tests/test_expression.cpp
+++ b/tests/test_expression.cpp
@@ -1,0 +1,20 @@
+#include "expression.hpp"
+#include <cassert>
+#include <iostream>
+
+int main() {
+    // price > 10
+    auto tokens1 = tokenize("price > 10");
+    auto ast1 = parse_expression(tokens1);
+    std::string code1 = ast1->to_cuda_expr();
+    assert(code1 == "(price[idx] > 10.0f)");
+
+    // quantity <= 5
+    auto tokens2 = tokenize("quantity <= 5");
+    auto ast2 = parse_expression(tokens2);
+    std::string code2 = ast2->to_cuda_expr();
+    assert(code2 == "(quantity[idx] <= 5.0f)");
+
+    std::cout << "All parser tests passed\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary
- extend expression parser to handle comparison operators
- ensure no leftover tokens after parsing
- add C++ unit tests for the parser

## Testing
- `g++ -std=c++17 -Iinclude tests/test_expression.cpp src/expression.cpp -o expression_test && ./expression_test`

------
https://chatgpt.com/codex/tasks/task_e_6840c28d982c8328ae59b2eca2380b1b