### PR TITLE
Fix char classification

### DIFF
--- a/src/expression.cpp
+++ b/src/expression.cpp
@@ -7,20 +7,24 @@ std::vector<Token> tokenize(const std::string &input) {
   size_t i = 0;
 
   while (i < input.size()) {
-    if (std::isspace(input[i])) {
+    if (std::isspace(static_cast<unsigned char>(input[i]))) {
       i++;
       continue;
     }
 
-    if (std::isalpha(input[i])) {
+    if (std::isalpha(static_cast<unsigned char>(input[i]))) {
       std::string ident;
-      while (i < input.size() && std::isalnum(input[i])) {
+      while (i < input.size() &&
+             std::isalnum(static_cast<unsigned char>(input[i]))) {
         ident += input[i++];
       }
       tokens.push_back({TokenType::Identifier, ident});
-    } else if (std::isdigit(input[i]) || input[i] == '.') {
+    } else if (std::isdigit(static_cast<unsigned char>(input[i])) ||
+               input[i] == '.') {
       std::string num;
-      while (i < input.size() && (std::isdigit(input[i]) || input[i] == '.')) {
+      while (i < input.size() &&
+             (std::isdigit(static_cast<unsigned char>(input[i])) ||
+              input[i] == '.')) {
         num += input[i++];
       }
       tokens.push_back({TokenType::Number, num});

--- a/src/main.cu
+++ b/src/main.cu
@@ -78,7 +78,7 @@ int main(int argc, char **argv) {
   std::string user_query = argv[1];
   std::string upper_query = user_query;
   for (auto &c : upper_query)
-    c = std::toupper(c);
+    c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
 
   std::string expr_part = user_query;
   std::string where_part;


### PR DESCRIPTION
## Summary
- avoid UB in parser by casting to `unsigned char` for `is*` calls
- avoid UB in query conversion by casting before `std::toupper`

## Testing
- `g++ -std=c++17 -Iinclude tests/test_expression.cpp src/expression.cpp -o test_expr && ./test_expr`
- `g++ -std=c++17 -Iinclude tests/expression_tests.cpp src/expression.cpp -o expression_tests && ./expression_tests`
- `cmake ..` *(fails: Failed to find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6845bd6b551c83288aaf76f38e453573