### PR TITLE
Add basic C++ API and Python bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,3 +28,18 @@ add_executable(expression_test
 
 add_test(NAME expression_test COMMAND expression_test)
 
+add_library(warpdb_lib STATIC
+    src/warpdb.cpp
+    src/csv_loader.cpp
+    src/expression.cpp
+    src/jit.cpp
+)
+set_target_properties(warpdb_lib PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
+target_link_libraries(warpdb_lib PUBLIC CUDA::nvrtc CUDA::cuda_driver)
+
+find_package(pybind11 CONFIG QUIET)
+if(pybind11_FOUND)
+    pybind11_add_module(pywarpdb bindings/python/pywarpdb.cpp)
+    target_link_libraries(pywarpdb PRIVATE warpdb_lib)
+endif()
+

--- a/README.md
+++ b/README.md
@@ -56,6 +56,18 @@ make
 ./warpdb "query_expression [WHERE condition]"
 ```
 
+### Python API
+
+You can also use WarpDB directly from Python if `pybind11` is available:
+
+```python
+import pywarpdb
+
+db = pywarpdb.WarpDB("data/test.csv")
+result = db.query("price * quantity WHERE price > 10")
+print(result)
+```
+
 ### Example Queries
 
 ```bash

--- a/bindings/python/pywarpdb.cpp
+++ b/bindings/python/pywarpdb.cpp
@@ -1,0 +1,11 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include "warpdb.hpp"
+
+namespace py = pybind11;
+
+PYBIND11_MODULE(pywarpdb, m) {
+    py::class_<WarpDB>(m, "WarpDB")
+        .def(py::init<const std::string &>())
+        .def("query", &WarpDB::query);
+}

--- a/include/warpdb.hpp
+++ b/include/warpdb.hpp
@@ -1,0 +1,20 @@
+#pragma once
+#include <string>
+#include <vector>
+
+#include "csv_loader.hpp"
+#include "expression.hpp"
+#include "jit.hpp"
+
+class WarpDB {
+public:
+    explicit WarpDB(const std::string &csv_path);
+    ~WarpDB();
+
+    // Execute an expression with optional WHERE clause.
+    // Example: "price * quantity WHERE price > 10"
+    std::vector<float> query(const std::string &expr);
+
+private:
+    Table table_;
+};

--- a/src/warpdb.cpp
+++ b/src/warpdb.cpp
@@ -1,0 +1,48 @@
+#include "warpdb.hpp"
+#include <cuda_runtime.h>
+#include <algorithm>
+#include <cctype>
+#include <iostream>
+
+WarpDB::WarpDB(const std::string &csv_path) {
+    table_ = load_csv_to_gpu(csv_path);
+}
+
+WarpDB::~WarpDB() {
+    cudaFree(table_.d_price);
+    cudaFree(table_.d_quantity);
+}
+
+std::vector<float> WarpDB::query(const std::string &expr) {
+    std::string upper = expr;
+    for (auto &c : upper) c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
+
+    std::string expr_part = expr;
+    std::string where_part;
+    auto where_pos = upper.find("WHERE");
+    if (where_pos != std::string::npos) {
+        expr_part = expr.substr(0, where_pos);
+        where_part = expr.substr(where_pos + 5);
+    }
+
+    auto expr_tokens = tokenize(expr_part);
+    auto expr_ast = parse_expression(expr_tokens);
+    std::string expr_cuda = expr_ast->to_cuda_expr();
+
+    std::string condition_cuda;
+    if (!where_part.empty()) {
+        auto cond_tokens = tokenize(where_part);
+        auto cond_ast = parse_expression(cond_tokens);
+        condition_cuda = cond_ast->to_cuda_expr();
+    }
+
+    float *d_output;
+    cudaMalloc(&d_output, sizeof(float) * table_.num_rows);
+
+    jit_compile_and_launch(expr_cuda, condition_cuda, table_.d_price, table_.d_quantity, d_output, table_.num_rows);
+
+    std::vector<float> result(table_.num_rows);
+    cudaMemcpy(result.data(), d_output, sizeof(float) * table_.num_rows, cudaMemcpyDeviceToHost);
+    cudaFree(d_output);
+    return result;
+}

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1,0 +1,5 @@
+import pywarpdb
+
+db = pywarpdb.WarpDB("data/test.csv")
+result = db.query("price + 1")
+print("rows", len(result))


### PR DESCRIPTION
## Summary
- provide a simple C++ `WarpDB` class in `warpdb.hpp/warpdb.cpp`
- build a static library and optional Python module using pybind11
- update CMakeLists.txt accordingly
- document usage of the new Python API
- add minimal python test

## Testing
- `cmake -S . -B build` *(fails: Failed to find nvcc)*
- `ctest --test-dir build` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_6845be67e46c8328bc19983efd4a69e9