### PR TITLE
Add custom CUDA injection support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ WarpDB is a GPU-accelerated SQL query engine that demonstrates how to leverage C
 - **Expression Parsing & Code Generation**: Parse SQL-like expressions and automatically generate optimized CUDA code
 - **CSV Data Loading**: Efficiently load data from CSV files directly to GPU memory
 - **CUDA-Based Data Filtering & Projection**: Filter and transform data in parallel on the GPU
+- **User-Provided CUDA Functions**: Extend queries with functions defined in `custom.cu`
 
 ## Architecture
 
@@ -56,6 +57,27 @@ make
 ./warpdb "query_expression [WHERE condition]"
 ```
 
+### Custom CUDA Functions
+
+WarpDB looks for a file named `custom.cu` in the working directory at runtime.
+Any functions defined in this file are appended to the generated kernel and can
+be used in expressions. Functions should be marked with `__device__` so they are
+callable from GPU kernels.
+
+Example `custom.cu`:
+
+```cpp
+__device__ float discount(float price, float rate) {
+    return price * rate;
+}
+```
+
+You can then invoke the function in a query:
+
+```bash
+./warpdb "discount(price, 0.9)"
+```
+
 ### Example Queries
 
 ```bash
@@ -82,6 +104,7 @@ make
 │   ├── csv_loader.hpp      # CSV loading interface
 │   ├── expression.hpp      # Expression parsing
 │   └── jit.hpp             # JIT compilation interface
+├── custom.cu               # User-provided CUDA functions (optional)
 └── src/                    # Source files
     ├── csv_loader.cpp      # CSV loading implementation
     ├── expression.cpp      # Expression parsing implementation

--- a/custom.cu
+++ b/custom.cu
@@ -1,0 +1,3 @@
+__device__ float discount(float price, float rate) {
+    return price * rate;
+}

--- a/include/expression.hpp
+++ b/include/expression.hpp
@@ -12,7 +12,7 @@ struct Token {
 
 std::vector<Token> tokenize(const std::string &input);
 
-enum class ASTNodeType { Constant, Variable, BinaryOp };
+enum class ASTNodeType { Constant, Variable, BinaryOp, FunctionCall };
 
 struct ASTNode {
   virtual ~ASTNode() {}
@@ -55,6 +55,24 @@ struct BinaryOpNode : public ASTNode {
   }
 
   ASTNodeType type() const override { return ASTNodeType::BinaryOp; }
+};
+
+struct FunctionCallNode : public ASTNode {
+  std::string name;
+  std::vector<ASTNodePtr> args;
+  FunctionCallNode(std::string n, std::vector<ASTNodePtr> a)
+      : name(std::move(n)), args(std::move(a)) {}
+  std::string to_cuda_expr() const override {
+    std::string result = name + "(";
+    for (size_t i = 0; i < args.size(); ++i) {
+      if (i > 0)
+        result += ", ";
+      result += args[i]->to_cuda_expr();
+    }
+    result += ")";
+    return result;
+  }
+  ASTNodeType type() const override { return ASTNodeType::FunctionCall; }
 };
 
 // Entry point

--- a/src/expression.cpp
+++ b/src/expression.cpp
@@ -12,10 +12,11 @@ std::vector<Token> tokenize(const std::string &input) {
       continue;
     }
 
-    if (std::isalpha(static_cast<unsigned char>(input[i]))) {
+    if (std::isalpha(static_cast<unsigned char>(input[i])) || input[i] == '_') {
       std::string ident;
       while (i < input.size() &&
-             std::isalnum(static_cast<unsigned char>(input[i]))) {
+             (std::isalnum(static_cast<unsigned char>(input[i])) ||
+              input[i] == '_')) {
         ident += input[i++];
       }
       tokens.push_back({TokenType::Identifier, ident});
@@ -38,7 +39,7 @@ std::vector<Token> tokenize(const std::string &input) {
       }
       i++;
       tokens.push_back({TokenType::Operator, op});
-    } else if (std::string("+-*/()<>").find(input[i]) != std::string::npos) {
+    } else if (std::string("+-*/()<>,").find(input[i]) != std::string::npos) {
       // Remaining single-character operators
       tokens.push_back({TokenType::Operator, std::string(1, input[i++])});
     } else {
@@ -114,8 +115,20 @@ ASTNodePtr parse_factor() {
     advance();
     return std::make_unique<ConstantNode>(tok.value);
   } else if (tok.type == TokenType::Identifier) {
+    std::string ident = tok.value;
     advance();
-    return std::make_unique<VariableNode>(tok.value);
+    if (match("(")) {
+      std::vector<ASTNodePtr> args;
+      if (!match(")")) {
+        do {
+          args.push_back(parse_expression_internal());
+        } while (match(","));
+        if (!match(")"))
+          throw std::runtime_error("Expected ')' after arguments");
+      }
+      return std::make_unique<FunctionCallNode>(ident, std::move(args));
+    }
+    return std::make_unique<VariableNode>(ident);
   } else if (match("(")) {
     ASTNodePtr node = parse_expression_internal();
     if (!match(")"))

--- a/src/jit.cpp
+++ b/src/jit.cpp
@@ -4,6 +4,8 @@
 #include <iostream>
 #include <nvrtc.h>
 #include <stdexcept>
+#include <fstream>
+#include <sstream>
 
 #define NVRTC_CHECK(stmt)                                                      \
   do {                                                                         \
@@ -35,7 +37,17 @@ void jit_compile_and_launch(const std::string &expr_code,
     body = "output[idx] = " + expr_code + ";";
   }
 
-  std::string kernel = R"(
+  std::string custom_code;
+  {
+    std::ifstream in("custom.cu");
+    if (in) {
+      std::stringstream ss;
+      ss << in.rdbuf();
+      custom_code = ss.str();
+    }
+  }
+
+  std::string kernel = custom_code + R"(
     extern "C" __global__
     void user_kernel(float* price, int* quantity, float* output, int N) {
         int idx = blockIdx.x * blockDim.x + threadIdx.x;

--- a/tests/test_expression.cpp
+++ b/tests/test_expression.cpp
@@ -15,6 +15,12 @@ int main() {
     std::string code2 = ast2->to_cuda_expr();
     assert(code2 == "(quantity[idx] <= 5.0f)");
 
+    // custom function call
+    auto tokens3 = tokenize("discount(price, 0.9)");
+    auto ast3 = parse_expression(tokens3);
+    std::string code3 = ast3->to_cuda_expr();
+    assert(code3 == "discount(price[idx], 0.9f)");
+
     std::cout << "All parser tests passed\n";
     return 0;
 }


### PR DESCRIPTION
## Summary
- support user-defined CUDA functions in `custom.cu`
- extend expression parser with function call nodes
- inject `custom.cu` at JIT compile time
- document custom function usage in README
- test parser with a custom function call

## Testing
- `g++ tests/test_expression.cpp src/expression.cpp -Iinclude -std=c++17 -o expr_test && ./expr_test`
- `g++ tests/expression_tests.cpp src/expression.cpp -Iinclude -std=c++17 -o expr_error_test && ./expr_error_test`


------
https://chatgpt.com/codex/tasks/task_e_6845be62b1008328b0bdf21158230f89