### PR TITLE
Add optional Apache Arrow columnar support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,21 +5,38 @@ project(WarpDB LANGUAGES CXX CUDA)
 set(CMAKE_CXX_STANDARD 17)
 
 find_package(CUDAToolkit REQUIRED)
+find_package(Arrow QUIET COMPONENTS cuda)
+
+if(Arrow_FOUND)
+    message(STATUS "Found Apache Arrow: ${Arrow_VERSION}")
+    add_definitions(-DUSE_ARROW)
+    include_directories(${Arrow_INCLUDE_DIRS})
+endif()
 
 include_directories(include)
 
-add_executable(warpdb
+set(WARPDB_SRC
     src/main.cu
     src/csv_loader.cpp
     src/expression.cpp
     src/jit.cpp
 )
 
+if(Arrow_FOUND)
+    list(APPEND WARPDB_SRC src/arrow_loader.cpp)
+endif()
+
+add_executable(warpdb ${WARPDB_SRC})
+
 set_target_properties(warpdb PROPERTIES
     CUDA_SEPARABLE_COMPILATION ON
 )
 
-target_link_libraries(warpdb PRIVATE CUDA::nvrtc CUDA::cuda_driver)
+if(Arrow_FOUND)
+    target_link_libraries(warpdb PRIVATE CUDA::nvrtc CUDA::cuda_driver ${Arrow_LIBRARIES})
+else()
+    target_link_libraries(warpdb PRIVATE CUDA::nvrtc CUDA::cuda_driver)
+endif()
 
 add_executable(expression_test
     tests/test_expression.cpp

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ WarpDB is a GPU-accelerated SQL query engine that demonstrates how to leverage C
 - **Expression Parsing & Code Generation**: Parse SQL-like expressions and automatically generate optimized CUDA code
 - **CSV Data Loading**: Efficiently load data from CSV files directly to GPU memory
 - **CUDA-Based Data Filtering & Projection**: Filter and transform data in parallel on the GPU
+- **Arrow Columnar Format**: Optionally load data using Apache Arrow for zero-copy
+  interoperability with Pandas, PyTorch, and Spark
 
 ## Architecture
 
@@ -17,6 +19,12 @@ WarpDB consists of the following main components:
 ### CSV Loader
 - Loads CSV data directly into GPU memory with minimal CPU intervention
 - Handles data type conversion and memory allocation
+
+### Arrow Integration
+- When Apache Arrow is available, WarpDB loads data into Arrow tables and
+  transfers columns to GPU memory using Arrow's CUDA support. Arrow buffers can
+  be shared across processes and enable efficient zero-copy interchange with
+  other systems.
 
 ### SQL Parser
 - Tokenizes and parses SQL-like expressions into an Abstract Syntax Tree (AST)
@@ -36,6 +44,7 @@ WarpDB consists of the following main components:
 - CMake 3.18 or higher
 - C++17 compatible compiler
 - NVIDIA GPU with compute capability 7.0 or higher
+- [Optional] Apache Arrow with CUDA support for zero-copy columnar data
 
 The build system uses `find_package(CUDAToolkit)` to automatically locate
 NVRTC and the CUDA driver. Ensure the CUDA toolkit is installed and available
@@ -47,6 +56,7 @@ in your environment.
 mkdir build
 cd build
 cmake ..  # CMake will locate the CUDA toolkit automatically
+# Arrow is discovered via `find_package(Arrow)` when available
 make
 ```
 

--- a/include/arrow_loader.hpp
+++ b/include/arrow_loader.hpp
@@ -1,0 +1,19 @@
+#pragma once
+#include <memory>
+#include <string>
+#ifdef USE_ARROW
+#include <arrow/api.h>
+#include <arrow/cuda/api.h>
+#endif
+
+struct ArrowTable {
+#ifdef USE_ARROW
+    std::shared_ptr<arrow::cuda::CudaBuffer> d_price;
+    std::shared_ptr<arrow::cuda::CudaBuffer> d_quantity;
+    int64_t num_rows;
+#endif
+};
+
+#ifdef USE_ARROW
+ArrowTable load_csv_arrow(const std::string &filepath);
+#endif

--- a/include/csv_loader.hpp
+++ b/include/csv_loader.hpp
@@ -1,10 +1,20 @@
 #pragma once
 #include <string>
 #include <vector>
+#ifdef USE_ARROW
+#include <memory>
+#include <arrow/api.h>
+#include <arrow/cuda/api.h>
+#endif
 
 struct Table {
+#ifdef USE_ARROW
+  std::shared_ptr<arrow::cuda::CudaBuffer> d_price; // Device buffers
+  std::shared_ptr<arrow::cuda::CudaBuffer> d_quantity;
+#else
   float *d_price; // Device pointers
   int *d_quantity;
+#endif
   int num_rows;
 };
 

--- a/src/arrow_loader.cpp
+++ b/src/arrow_loader.cpp
@@ -1,0 +1,55 @@
+#ifdef USE_ARROW
+#include "arrow_loader.hpp"
+#include <arrow/csv/api.h>
+#include <arrow/io/api.h>
+#include <arrow/result.h>
+#include <arrow/util/logging.h>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+
+ArrowTable load_csv_arrow(const std::string &filepath) {
+    auto input_res = arrow::io::ReadableFile::Open(filepath);
+    if (!input_res.ok()) {
+        throw std::runtime_error(input_res.status().ToString());
+    }
+    std::shared_ptr<arrow::io::InputStream> input = *input_res;
+
+    auto read_opts = arrow::csv::ReadOptions::Defaults();
+    auto parse_opts = arrow::csv::ParseOptions::Defaults();
+    auto convert_opts = arrow::csv::ConvertOptions::Defaults();
+
+    ARROW_ASSIGN_OR_RAISE(
+        auto reader,
+        arrow::csv::TableReader::Make(arrow::io::IOContext(), input, read_opts,
+                                      parse_opts, convert_opts));
+
+    ARROW_ASSIGN_OR_RAISE(auto table, reader->Read());
+
+    int64_t num_rows = table->num_rows();
+
+    auto price_array = std::static_pointer_cast<arrow::FloatArray>(
+        table->GetColumnByName("price")->chunk(0));
+    auto qty_array = std::static_pointer_cast<arrow::Int32Array>(
+        table->GetColumnByName("quantity")->chunk(0));
+
+    std::shared_ptr<arrow::cuda::CudaDeviceManager> manager;
+    ARROW_THROW_NOT_OK(arrow::cuda::CudaDeviceManager::GetInstance(&manager));
+    std::shared_ptr<arrow::cuda::CudaContext> context;
+    ARROW_THROW_NOT_OK(manager->GetContext(0, &context));
+
+    std::shared_ptr<arrow::cuda::CudaBuffer> d_price;
+    std::shared_ptr<arrow::cuda::CudaBuffer> d_quantity;
+    ARROW_THROW_NOT_OK(context->AllocateBuffer(sizeof(float) * num_rows, &d_price));
+    ARROW_THROW_NOT_OK(context->AllocateBuffer(sizeof(int32_t) * num_rows, &d_quantity));
+
+    ARROW_THROW_NOT_OK(
+        context->CopyHostToDevice(d_price->address(), price_array->raw_values(),
+                                  sizeof(float) * num_rows));
+    ARROW_THROW_NOT_OK(
+        context->CopyHostToDevice(d_quantity->address(), qty_array->raw_values(),
+                                  sizeof(int32_t) * num_rows));
+
+    return {d_price, d_quantity, num_rows};
+}
+#endif

--- a/src/main.cu
+++ b/src/main.cu
@@ -141,10 +141,23 @@ int main(int argc, char **argv) {
   cudaMemset(d_multi_count, 0, sizeof(int));
   std::cout << "Allocated space\n";
 
-  print_first_few<<<1, 4>>>(table.d_price, table.d_quantity, table.num_rows);
+  print_first_few<<<1, 4>>>(
+#ifdef USE_ARROW
+      reinterpret_cast<float *>(table.d_price->mutable_data()),
+      reinterpret_cast<int *>(table.d_quantity->mutable_data()),
+#else
+      table.d_price, table.d_quantity,
+#endif
+      table.num_rows);
   cudaDeviceSynchronize();
 
-  filter_price_gt<<<blocks, threads>>>(table.d_price, table.d_quantity,
+  filter_price_gt<<<blocks, threads>>>(
+#ifdef USE_ARROW
+                                       reinterpret_cast<float *>(table.d_price->mutable_data()),
+                                       reinterpret_cast<int *>(table.d_quantity->mutable_data()),
+#else
+                                       table.d_price, table.d_quantity,
+#endif
                                        d_price_filtered, d_quantity_filtered,
                                        d_count, table.num_rows, threshold);
   cudaDeviceSynchronize();
@@ -165,8 +178,14 @@ int main(int argc, char **argv) {
 
   std::cout << "\nRunning SELECT projection:\n";
   project_columns<<<blocks, threads>>>(
-      table.d_price, table.d_quantity, d_selected_price, d_selected_quantity,
-      d_select_count, table.num_rows, select_price, select_quantity);
+#ifdef USE_ARROW
+      reinterpret_cast<float *>(table.d_price->mutable_data()),
+      reinterpret_cast<int *>(table.d_quantity->mutable_data()),
+#else
+      table.d_price, table.d_quantity,
+#endif
+      d_selected_price, d_selected_quantity, d_select_count, table.num_rows,
+      select_price, select_quantity);
   cudaDeviceSynchronize();
 
   cudaMemcpy(&h_select_count, d_select_count, sizeof(int),
@@ -190,9 +209,14 @@ int main(int argc, char **argv) {
 
   std::cout << "\nRunning SELECT revenue (price * quantity) with WHERE price > "
                "threshold:\n";
-  project_revenue<<<blocks, threads>>>(table.d_price, table.d_quantity,
-                                       d_revenue, d_revenue_count,
-                                       table.num_rows, threshold);
+  project_revenue<<<blocks, threads>>>(
+#ifdef USE_ARROW
+      reinterpret_cast<float *>(table.d_price->mutable_data()),
+      reinterpret_cast<int *>(table.d_quantity->mutable_data()),
+#else
+      table.d_price, table.d_quantity,
+#endif
+      d_revenue, d_revenue_count, table.num_rows, threshold);
   cudaDeviceSynchronize();
 
   cudaMemcpy(&h_revenue_count, d_revenue_count, sizeof(int),
@@ -209,8 +233,14 @@ int main(int argc, char **argv) {
 
   std::cout << "\nRunning SELECT revenue and adjusted_price:\n";
   project_revenue_and_adjusted<<<blocks, threads>>>(
-      table.d_price, table.d_quantity, d_revenue_multi, d_adjusted_price,
-      d_multi_count, table.num_rows, threshold);
+#ifdef USE_ARROW
+      reinterpret_cast<float *>(table.d_price->mutable_data()),
+      reinterpret_cast<int *>(table.d_quantity->mutable_data()),
+#else
+      table.d_price, table.d_quantity,
+#endif
+      d_revenue_multi, d_adjusted_price, d_multi_count, table.num_rows,
+      threshold);
   cudaDeviceSynchronize();
 
   cudaMemcpy(&h_multi_count, d_multi_count, sizeof(int),
@@ -260,8 +290,14 @@ int main(int argc, char **argv) {
 
   // compile
   std::cout << "\n[ JIT Kernel Execution for Expression ]\n";
-  jit_compile_and_launch(expr_cuda, condition_cuda, table.d_price,
-                         table.d_quantity, d_jit_output, table.num_rows);
+  jit_compile_and_launch(expr_cuda, condition_cuda,
+#ifdef USE_ARROW
+                         reinterpret_cast<float *>(table.d_price->mutable_data()),
+                         reinterpret_cast<int *>(table.d_quantity->mutable_data()),
+#else
+                         table.d_price, table.d_quantity,
+#endif
+                         d_jit_output, table.num_rows);
 
   float *h_jit_output = new float[table.num_rows];
   cudaMemcpy(h_jit_output, d_jit_output, sizeof(float) * table.num_rows,
@@ -291,8 +327,10 @@ int main(int argc, char **argv) {
   cudaFree(d_price_filtered);
   cudaFree(d_quantity_filtered);
   cudaFree(d_count);
+#ifndef USE_ARROW
   cudaFree(table.d_price);
   cudaFree(table.d_quantity);
+#endif
 
   return 0;
 }


### PR DESCRIPTION
## Summary
- add optional Apache Arrow dependency in CMake
- implement `ArrowTable` loader using Arrow CUDA buffers
- update CSV loader and main code to use Arrow when available
- document Arrow integration in README

## Testing
- `cmake ..` *(fails: Failed to find nvcc)*
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_6845be4ec0b48328bea55c5ffa881195