### PR TITLE
Add multi-GPU example

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ make
 ./warpdb "price * quantity * 1.08"
 ```
 
+### Multi-GPU Example
+
+WarpDB includes a helper `run_multi_gpu_jit` demonstrating how to split the
+input table across available GPUs and execute the same JIT-compiled kernel on
+each device. Results are aggregated back on the host.
+
 ## Project Structure
 
 ```

--- a/include/csv_loader.hpp
+++ b/include/csv_loader.hpp
@@ -8,4 +8,12 @@ struct Table {
   int num_rows;
 };
 
+struct HostTable {
+  std::vector<float> price;
+  std::vector<int> quantity;
+  int num_rows() const { return static_cast<int>(price.size()); }
+};
+
+HostTable load_csv_to_host(const std::string &filepath);
+Table upload_to_gpu(const HostTable &table);
 Table load_csv_to_gpu(const std::string &filepath);

--- a/include/jit.hpp
+++ b/include/jit.hpp
@@ -2,6 +2,6 @@
 #include <string>
 
 void jit_compile_and_launch(const std::string &expr_code,
-                            const std::string &condition_code, // new!
+                            const std::string &condition_code,
                             float *d_price, int *d_quantity, float *d_output,
-                            int N);
+                            int N, int device_id = 0);

--- a/src/csv_loader.cpp
+++ b/src/csv_loader.cpp
@@ -13,7 +13,7 @@
     }                                                                          \
   } while (0)
 
-Table load_csv_to_gpu(const std::string &filepath) {
+HostTable load_csv_to_host(const std::string &filepath) {
   std::ifstream file(filepath);
   if (!file.is_open()) {
     std::cerr << "Failed to open file: " << filepath << std::endl;
@@ -36,7 +36,14 @@ Table load_csv_to_gpu(const std::string &filepath) {
     h_quantity.push_back(std::stoi(qty_str));
   }
 
-  const int N = h_price.size();
+  HostTable table;
+  table.price = std::move(h_price);
+  table.quantity = std::move(h_quantity);
+  return table;
+}
+
+Table upload_to_gpu(const HostTable &host) {
+  const int N = host.num_rows();
 
   // Allocate pinned host memory (optional for now)
   float *h_price_pinned;
@@ -44,8 +51,8 @@ Table load_csv_to_gpu(const std::string &filepath) {
   CUDA_CHECK(cudaMallocHost((void **)&h_price_pinned, sizeof(float) * N));
   CUDA_CHECK(cudaMallocHost((void **)&h_quantity_pinned, sizeof(int) * N));
 
-  std::copy(h_price.begin(), h_price.end(), h_price_pinned);
-  std::copy(h_quantity.begin(), h_quantity.end(), h_quantity_pinned);
+  std::copy(host.price.begin(), host.price.end(), h_price_pinned);
+  std::copy(host.quantity.begin(), host.quantity.end(), h_quantity_pinned);
 
   // Allocate device memory
   float *d_price;
@@ -65,4 +72,9 @@ Table load_csv_to_gpu(const std::string &filepath) {
 
   Table table = {d_price, d_quantity, N};
   return table;
+}
+
+Table load_csv_to_gpu(const std::string &filepath) {
+  HostTable host = load_csv_to_host(filepath);
+  return upload_to_gpu(host);
 }

--- a/src/jit.cpp
+++ b/src/jit.cpp
@@ -26,7 +26,8 @@
 
 void jit_compile_and_launch(const std::string &expr_code,
                             const std::string &condition_code, float *d_price,
-                            int *d_quantity, float *d_output, int N) {
+                            int *d_quantity, float *d_output, int N,
+                            int device_id) {
   std::string body;
   if (!condition_code.empty()) {
     body = "if (" + condition_code + ") {\n    output[idx] = " + expr_code +
@@ -87,7 +88,7 @@ void jit_compile_and_launch(const std::string &expr_code,
   CUmodule module;
   CUfunction kernel_func;
   CU_CHECK(cuInit(0));
-  CU_CHECK(cuDeviceGet(&cuDevice, 0));
+  CU_CHECK(cuDeviceGet(&cuDevice, device_id));
   CU_CHECK(cuCtxCreate(&context, 0, cuDevice));
   CU_CHECK(cuModuleLoadDataEx(&module, ptx.c_str(), 0, nullptr, nullptr));
   CU_CHECK(cuModuleGetFunction(&kernel_func, module, "user_kernel"));

--- a/src/main.cu
+++ b/src/main.cu
@@ -6,6 +6,56 @@
 #include "expression.hpp"
 #include "jit.hpp"
 
+// Simple multi-GPU execution of a JIT compiled expression.
+// Splits the input table across all available devices and aggregates the output.
+void run_multi_gpu_jit(const std::string &expr_cuda,
+                       const std::string &cond_cuda) {
+  HostTable host = load_csv_to_host("data/test.csv");
+
+  int device_count = 0;
+  cudaGetDeviceCount(&device_count);
+  if (device_count < 2) {
+    std::cout << "Only " << device_count
+              << " GPU detected. Skipping multi-device example.\n";
+    return;
+  }
+
+  int N = host.num_rows();
+  int chunk = (N + device_count - 1) / device_count;
+  std::vector<float> results(N);
+
+  for (int dev = 0; dev < device_count; ++dev) {
+    int start = dev * chunk;
+    int end = std::min(start + chunk, N);
+    if (start >= end)
+      break;
+    int local_N = end - start;
+
+    HostTable sub;
+    sub.price.assign(host.price.begin() + start, host.price.begin() + end);
+    sub.quantity.assign(host.quantity.begin() + start,
+                        host.quantity.begin() + end);
+    Table dtab = upload_to_gpu(sub);
+
+    float *d_out;
+    cudaMalloc(&d_out, sizeof(float) * local_N);
+
+    jit_compile_and_launch(expr_cuda, cond_cuda, dtab.d_price, dtab.d_quantity,
+                           d_out, local_N, dev);
+
+    cudaMemcpy(results.data() + start, d_out, sizeof(float) * local_N,
+               cudaMemcpyDeviceToHost);
+
+    cudaFree(d_out);
+    cudaFree(dtab.d_price);
+    cudaFree(dtab.d_quantity);
+  }
+
+  for (int i = 0; i < N; ++i) {
+    std::cout << "MultiGPU Result[" << i << "] = " << results[i] << "\n";
+  }
+}
+
 __global__ void print_first_few(float *price, int *quantity, int N) {
   int idx = threadIdx.x;
   if (idx < N && idx < 4) {
@@ -261,7 +311,7 @@ int main(int argc, char **argv) {
   // compile
   std::cout << "\n[ JIT Kernel Execution for Expression ]\n";
   jit_compile_and_launch(expr_cuda, condition_cuda, table.d_price,
-                         table.d_quantity, d_jit_output, table.num_rows);
+                         table.d_quantity, d_jit_output, table.num_rows, 0);
 
   float *h_jit_output = new float[table.num_rows];
   cudaMemcpy(h_jit_output, d_jit_output, sizeof(float) * table.num_rows,
@@ -269,6 +319,9 @@ int main(int argc, char **argv) {
   for (int i = 0; i < table.num_rows; ++i) {
     std::cout << "JIT Result[" << i << "] = " << h_jit_output[i] << "\n";
   }
+
+  std::cout << "\n[ Multi-GPU JIT Example ]\n";
+  run_multi_gpu_jit(expr_cuda, condition_cuda);
 
   delete[] h_jit_output;
   delete[] h_revenue_multi;


### PR DESCRIPTION
## Summary
- add `HostTable` loader for host-side CSV data
- support specifying a CUDA device in `jit_compile_and_launch`
- implement `run_multi_gpu_jit` example
- mention multi-GPU helper in README

## Testing
- `cmake ..` *(fails: Failed to find nvcc)*
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_6845be5aa6048328908cbd05bf784de4