### PR TITLE
Add Arrow-based columnar loaders

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,12 +5,14 @@ project(WarpDB LANGUAGES CXX CUDA)
 set(CMAKE_CXX_STANDARD 17)
 
 find_package(CUDAToolkit REQUIRED)
+find_package(Arrow REQUIRED)
 
 include_directories(include)
 
 add_executable(warpdb
     src/main.cu
     src/csv_loader.cpp
+    src/arrow_loader.cpp
     src/expression.cpp
     src/jit.cpp
 )
@@ -19,7 +21,7 @@ set_target_properties(warpdb PROPERTIES
     CUDA_SEPARABLE_COMPILATION ON
 )
 
-target_link_libraries(warpdb PRIVATE CUDA::nvrtc CUDA::cuda_driver)
+target_link_libraries(warpdb PRIVATE CUDA::nvrtc CUDA::cuda_driver Arrow::arrow Arrow::parquet)
 
 add_executable(expression_test
     tests/test_expression.cpp

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ WarpDB is a GPU-accelerated SQL query engine that demonstrates how to leverage C
 - **Dynamic CUDA Kernel Compilation**: JIT-compile custom CUDA kernels at runtime based on user expressions
 - **Expression Parsing & Code Generation**: Parse SQL-like expressions and automatically generate optimized CUDA code
 - **CSV Data Loading**: Efficiently load data from CSV files directly to GPU memory
+- **Parquet/Arrow/ORC Loading**: Use Apache Arrow to ingest columnar formats
 - **CUDA-Based Data Filtering & Projection**: Filter and transform data in parallel on the GPU
 
 ## Architecture
@@ -17,6 +18,10 @@ WarpDB consists of the following main components:
 ### CSV Loader
 - Loads CSV data directly into GPU memory with minimal CPU intervention
 - Handles data type conversion and memory allocation
+
+### Arrow Loader
+- Reads Parquet, Arrow, and ORC files using Apache Arrow
+- Transfers columns to GPU memory
 
 ### SQL Parser
 - Tokenizes and parses SQL-like expressions into an Abstract Syntax Tree (AST)
@@ -80,10 +85,12 @@ make
 │   └── test.csv            # Test data
 ├── include/                # Header files
 │   ├── csv_loader.hpp      # CSV loading interface
+│   ├── arrow_loader.hpp    # Parquet/Arrow/ORC loading interface
 │   ├── expression.hpp      # Expression parsing
 │   └── jit.hpp             # JIT compilation interface
 └── src/                    # Source files
     ├── csv_loader.cpp      # CSV loading implementation
+    ├── arrow_loader.cpp    # Columnar format loading implementation
     ├── expression.cpp      # Expression parsing implementation
     ├── jit.cpp             # JIT compilation implementation
     └── main.cu             # Main application and CUDA kernels
@@ -92,11 +99,12 @@ make
 ## How It Works
 
 1. **CSV Loading**: Input data is loaded from CSV files directly into GPU memory.
-2. **Query Parsing**: User queries are tokenized and parsed into an AST.
-3. **Code Generation**: The AST is converted into CUDA code.
-4. **JIT Compilation**: The generated code is compiled into a CUDA kernel using NVRTC.
-5. **Execution**: The compiled kernel is executed on the GPU.
-6. **Result Retrieval**: Results are copied back to host memory and displayed.
+2. **Columnar Loading**: Parquet, Arrow, and ORC files are read via Apache Arrow and moved to GPU memory.
+3. **Query Parsing**: User queries are tokenized and parsed into an AST.
+4. **Code Generation**: The AST is converted into CUDA code.
+5. **JIT Compilation**: The generated code is compiled into a CUDA kernel using NVRTC.
+6. **Execution**: The compiled kernel is executed on the GPU.
+7. **Result Retrieval**: Results are copied back to host memory and displayed.
 
 ## Technical Details
 

--- a/include/arrow_loader.hpp
+++ b/include/arrow_loader.hpp
@@ -1,0 +1,7 @@
+#pragma once
+#include <string>
+#include "csv_loader.hpp" // for Table structure
+
+Table load_parquet_to_gpu(const std::string &filepath);
+Table load_arrow_to_gpu(const std::string &filepath);
+Table load_orc_to_gpu(const std::string &filepath);

--- a/src/arrow_loader.cpp
+++ b/src/arrow_loader.cpp
@@ -1,0 +1,69 @@
+#include "arrow_loader.hpp"
+#include <arrow/api.h>
+#include <arrow/io/file.h>
+#include <arrow/ipc/api.h>
+#include <parquet/arrow/reader.h>
+#include <arrow/adapters/orc/adapter.h>
+#include <cuda_runtime.h>
+#include <iostream>
+
+#define CUDA_CHECK(err) \
+  do { \
+    if (err != cudaSuccess) { \
+      std::cerr << "CUDA Error: " << cudaGetErrorString(err) << "\n"; \
+      exit(1); \
+    } \
+  } while (0)
+
+namespace {
+Table table_from_arrow(std::shared_ptr<arrow::Table> table) {
+  auto price_array = std::static_pointer_cast<arrow::DoubleArray>(table->GetColumnByName("price")->chunk(0));
+  auto quantity_array = std::static_pointer_cast<arrow::Int32Array>(table->GetColumnByName("quantity")->chunk(0));
+  int64_t N = table->num_rows();
+
+  float *d_price;
+  int *d_quantity;
+  CUDA_CHECK(cudaMalloc(&d_price, sizeof(float) * N));
+  CUDA_CHECK(cudaMalloc(&d_quantity, sizeof(int) * N));
+
+  std::vector<float> h_price(N);
+  std::vector<int> h_quantity(N);
+  for (int64_t i = 0; i < N; ++i) {
+    h_price[i] = static_cast<float>(price_array->Value(i));
+    h_quantity[i] = quantity_array->Value(i);
+  }
+
+  CUDA_CHECK(cudaMemcpy(d_price, h_price.data(), sizeof(float) * N, cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(d_quantity, h_quantity.data(), sizeof(int) * N, cudaMemcpyHostToDevice));
+
+  return {d_price, d_quantity, static_cast<int>(N)};
+}
+} // namespace
+
+Table load_parquet_to_gpu(const std::string &filepath) {
+  std::shared_ptr<arrow::io::ReadableFile> infile;
+  PARQUET_ASSIGN_OR_THROW(infile, arrow::io::ReadableFile::Open(filepath));
+  std::unique_ptr<parquet::arrow::FileReader> reader;
+  PARQUET_THROW_NOT_OK(parquet::arrow::OpenFile(infile, arrow::default_memory_pool(), &reader));
+  std::shared_ptr<arrow::Table> table;
+  PARQUET_THROW_NOT_OK(reader->ReadTable(&table));
+  return table_from_arrow(table);
+}
+
+Table load_arrow_to_gpu(const std::string &filepath) {
+  std::shared_ptr<arrow::io::ReadableFile> infile;
+  ARROW_ASSIGN_OR_RAISE(infile, arrow::io::ReadableFile::Open(filepath));
+  std::shared_ptr<arrow::ipc::RecordBatchFileReader> reader;
+  ARROW_ASSIGN_OR_RAISE(reader, arrow::ipc::RecordBatchFileReader::Open(infile));
+  std::shared_ptr<arrow::Table> table;
+  ARROW_ASSIGN_OR_RAISE(table, reader->ReadAll());
+  return table_from_arrow(table);
+}
+
+Table load_orc_to_gpu(const std::string &filepath) {
+  std::shared_ptr<arrow::io::ReadableFile> infile;
+  ARROW_ASSIGN_OR_RAISE(infile, arrow::io::ReadableFile::Open(filepath));
+  std::shared_ptr<arrow::Table> table;
+  ARROW_ASSIGN_OR_RAISE(table, arrow::adapters::orc::ORCFileReader::Read(*infile));
+  return table_from_arrow(table);
+}


### PR DESCRIPTION
## Summary
- introduce Parquet/Arrow/ORC loader using Arrow C++ APIs
- integrate the new loader in the CMake build
- document columnar loading support in README

## Testing
- `cmake ..` *(fails: Failed to find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6845be72a98483288ce36e31a99cc3cf