### PR TITLE
Add dynamic column schema registry

### DIFF
--- a/include/csv_loader.hpp
+++ b/include/csv_loader.hpp
@@ -2,10 +2,28 @@
 #include <string>
 #include <vector>
 
-struct Table {
-  float *d_price; // Device pointers
-  int *d_quantity;
-  int num_rows;
+enum class DataType { Int32, Float32 };
+
+struct ColumnDesc {
+  std::string name;
+  DataType type;
+  void *device_ptr;
+  int length;
 };
 
-Table load_csv_to_gpu(const std::string &filepath);
+struct Table {
+  std::vector<ColumnDesc> columns;
+  int num_rows;
+
+  template <typename T>
+  T *get_column_ptr(const std::string &name) const {
+    for (const auto &col : columns) {
+      if (col.name == name)
+        return static_cast<T *>(col.device_ptr);
+    }
+    return nullptr;
+  }
+};
+
+Table load_csv_to_gpu(const std::string &filepath,
+                      const std::vector<DataType> &schema = {});

--- a/include/jit.hpp
+++ b/include/jit.hpp
@@ -1,7 +1,8 @@
 #pragma once
 #include <string>
 
+#include "csv_loader.hpp"
+
 void jit_compile_and_launch(const std::string &expr_code,
-                            const std::string &condition_code, // new!
-                            float *d_price, int *d_quantity, float *d_output,
-                            int N);
+                            const std::string &condition_code,
+                            const Table &table, float *d_output);

--- a/src/csv_loader.cpp
+++ b/src/csv_loader.cpp
@@ -13,56 +13,92 @@
     }                                                                          \
   } while (0)
 
-Table load_csv_to_gpu(const std::string &filepath) {
+Table load_csv_to_gpu(const std::string &filepath,
+                      const std::vector<DataType> &schema) {
   std::ifstream file(filepath);
   if (!file.is_open()) {
     std::cerr << "Failed to open file: " << filepath << std::endl;
     throw std::runtime_error("Unable to open file");
   }
+
   std::string line;
-  std::vector<float> h_price;
-  std::vector<int> h_quantity;
-
-  // Skip header
+  // Read header
   std::getline(file, line);
+  std::vector<std::string> headers;
+  std::stringstream header_ss(line);
+  std::string cell;
+  while (std::getline(header_ss, cell, ',')) {
+    headers.push_back(cell);
+  }
+  const int num_cols = headers.size();
 
+  std::vector<std::vector<std::string>> raw_cols(num_cols);
   while (std::getline(file, line)) {
-    std::istringstream ss(line);
-    std::string price_str, qty_str;
-    std::getline(ss, price_str, ',');
-    std::getline(ss, qty_str, ',');
-
-    h_price.push_back(std::stof(price_str));
-    h_quantity.push_back(std::stoi(qty_str));
+    std::stringstream ss(line);
+    for (int c = 0; c < num_cols; ++c) {
+      std::string val;
+      std::getline(ss, val, ',');
+      raw_cols[c].push_back(val);
+    }
   }
 
-  const int N = h_price.size();
+  const int N = raw_cols[0].size();
 
-  // Allocate pinned host memory (optional for now)
-  float *h_price_pinned;
-  int *h_quantity_pinned;
-  CUDA_CHECK(cudaMallocHost((void **)&h_price_pinned, sizeof(float) * N));
-  CUDA_CHECK(cudaMallocHost((void **)&h_quantity_pinned, sizeof(int) * N));
+  std::vector<DataType> types = schema;
+  if (types.empty()) {
+    types.resize(num_cols);
+    for (int c = 0; c < num_cols; ++c) {
+      bool is_float = false;
+      for (const auto &v : raw_cols[c]) {
+        if (v.find('.') != std::string::npos || v.find('e') != std::string::npos ||
+            v.find('E') != std::string::npos) {
+          is_float = true;
+          break;
+        }
+      }
+      types[c] = is_float ? DataType::Float32 : DataType::Int32;
+    }
+  }
 
-  std::copy(h_price.begin(), h_price.end(), h_price_pinned);
-  std::copy(h_quantity.begin(), h_quantity.end(), h_quantity_pinned);
+  Table table;
+  table.num_rows = N;
 
-  // Allocate device memory
-  float *d_price;
-  int *d_quantity;
-  CUDA_CHECK(cudaMalloc((void **)&d_price, sizeof(float) * N));
-  CUDA_CHECK(cudaMalloc((void **)&d_quantity, sizeof(int) * N));
+  for (int c = 0; c < num_cols; ++c) {
+    ColumnDesc desc;
+    desc.name = headers[c];
+    desc.type = types[c];
+    desc.length = N;
 
-  // Copy to device
-  CUDA_CHECK(cudaMemcpy(d_price, h_price_pinned, sizeof(float) * N,
-                        cudaMemcpyHostToDevice));
-  CUDA_CHECK(cudaMemcpy(d_quantity, h_quantity_pinned, sizeof(int) * N,
-                        cudaMemcpyHostToDevice));
+    if (desc.type == DataType::Float32) {
+      std::vector<float> host(N);
+      for (int i = 0; i < N; ++i)
+        host[i] = std::stof(raw_cols[c][i]);
+      float *h_pinned;
+      CUDA_CHECK(cudaMallocHost((void **)&h_pinned, sizeof(float) * N));
+      std::copy(host.begin(), host.end(), h_pinned);
+      float *d_ptr;
+      CUDA_CHECK(cudaMalloc((void **)&d_ptr, sizeof(float) * N));
+      CUDA_CHECK(
+          cudaMemcpy(d_ptr, h_pinned, sizeof(float) * N, cudaMemcpyHostToDevice));
+      CUDA_CHECK(cudaFreeHost(h_pinned));
+      desc.device_ptr = d_ptr;
+    } else {
+      std::vector<int> host(N);
+      for (int i = 0; i < N; ++i)
+        host[i] = std::stoi(raw_cols[c][i]);
+      int *h_pinned;
+      CUDA_CHECK(cudaMallocHost((void **)&h_pinned, sizeof(int) * N));
+      std::copy(host.begin(), host.end(), h_pinned);
+      int *d_ptr;
+      CUDA_CHECK(cudaMalloc((void **)&d_ptr, sizeof(int) * N));
+      CUDA_CHECK(
+          cudaMemcpy(d_ptr, h_pinned, sizeof(int) * N, cudaMemcpyHostToDevice));
+      CUDA_CHECK(cudaFreeHost(h_pinned));
+      desc.device_ptr = d_ptr;
+    }
 
-  // Free pinned host mem
-  CUDA_CHECK(cudaFreeHost(h_price_pinned));
-  CUDA_CHECK(cudaFreeHost(h_quantity_pinned));
+    table.columns.push_back(desc);
+  }
 
-  Table table = {d_price, d_quantity, N};
   return table;
 }

--- a/src/jit.cpp
+++ b/src/jit.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <nvrtc.h>
 #include <stdexcept>
+#include <vector>
 
 #define NVRTC_CHECK(stmt)                                                      \
   do {                                                                         \
@@ -25,8 +26,8 @@
   } while (0)
 
 void jit_compile_and_launch(const std::string &expr_code,
-                            const std::string &condition_code, float *d_price,
-                            int *d_quantity, float *d_output, int N) {
+                            const std::string &condition_code,
+                            const Table &table, float *d_output) {
   std::string body;
   if (!condition_code.empty()) {
     body = "if (" + condition_code + ") {\n    output[idx] = " + expr_code +
@@ -35,14 +36,21 @@ void jit_compile_and_launch(const std::string &expr_code,
     body = "output[idx] = " + expr_code + ";";
   }
 
-  std::string kernel = R"(
-    extern "C" __global__
-    void user_kernel(float* price, int* quantity, float* output, int N) {
-        int idx = blockIdx.x * blockDim.x + threadIdx.x;
-        if (idx >= N) return;
-    )" + body + R"(
-    }
-    )";
+  std::string param_list;
+  for (size_t i = 0; i < table.columns.size(); ++i) {
+    const auto &col = table.columns[i];
+    param_list += (col.type == DataType::Float32 ? "float* " : "int* ");
+    param_list += col.name;
+    param_list += ", ";
+  }
+  param_list += "float* output, int N";
+
+  std::string kernel = "extern \"C\" __global__\n";
+  kernel += "void user_kernel(" + param_list + ") {\n";
+  kernel += "    int idx = blockIdx.x * blockDim.x + threadIdx.x;\n";
+  kernel += "    if (idx >= N) return;\n";
+  kernel += "    " + body + "\n";
+  kernel += "}";
 
   // Compile
   // RAII wrapper to destroy the NVRTC program in all code paths.
@@ -93,11 +101,18 @@ void jit_compile_and_launch(const std::string &expr_code,
   CU_CHECK(cuModuleGetFunction(&kernel_func, module, "user_kernel"));
 
   // Launch
-  void *args[] = {&d_price, &d_quantity, &d_output, &N};
+  std::vector<void *> args;
+  for (const auto &col : table.columns) {
+    args.push_back(const_cast<void *>(&col.device_ptr));
+  }
+  args.push_back(&d_output);
+  int N = table.num_rows;
+  args.push_back(&N);
+
   int threads = 128;
   int blocks = (N + threads - 1) / threads;
-  CU_CHECK(cuLaunchKernel(kernel_func, blocks, 1, 1, threads, 1, 1, 0, 0, args,
-                          nullptr));
+  CU_CHECK(cuLaunchKernel(kernel_func, blocks, 1, 1, threads, 1, 1, 0, 0,
+                          args.data(), nullptr));
   CU_CHECK(cuCtxSynchronize());
 
   // Cleanup

--- a/src/main.cu
+++ b/src/main.cu
@@ -94,6 +94,8 @@ int main(int argc, char **argv) {
 
   Table table = load_csv_to_gpu("data/test.csv");
   std::cout << "Loaded " << table.num_rows << " rows.\n";
+  float *d_price = table.get_column_ptr<float>("price");
+  int *d_quantity = table.get_column_ptr<int>("quantity");
 
   int *d_quantity_filtered;
   int *d_count;
@@ -141,12 +143,12 @@ int main(int argc, char **argv) {
   cudaMemset(d_multi_count, 0, sizeof(int));
   std::cout << "Allocated space\n";
 
-  print_first_few<<<1, 4>>>(table.d_price, table.d_quantity, table.num_rows);
+  print_first_few<<<1, 4>>>(d_price, d_quantity, table.num_rows);
   cudaDeviceSynchronize();
 
-  filter_price_gt<<<blocks, threads>>>(table.d_price, table.d_quantity,
-                                       d_price_filtered, d_quantity_filtered,
-                                       d_count, table.num_rows, threshold);
+  filter_price_gt<<<blocks, threads>>>(d_price, d_quantity, d_price_filtered,
+                                       d_quantity_filtered, d_count,
+                                       table.num_rows, threshold);
   cudaDeviceSynchronize();
 
   cudaMemcpy(&h_count, d_count, sizeof(int), cudaMemcpyDeviceToHost);
@@ -164,9 +166,10 @@ int main(int argc, char **argv) {
   }
 
   std::cout << "\nRunning SELECT projection:\n";
-  project_columns<<<blocks, threads>>>(
-      table.d_price, table.d_quantity, d_selected_price, d_selected_quantity,
-      d_select_count, table.num_rows, select_price, select_quantity);
+  project_columns<<<blocks, threads>>>(d_price, d_quantity, d_selected_price,
+                                       d_selected_quantity, d_select_count,
+                                       table.num_rows, select_price,
+                                       select_quantity);
   cudaDeviceSynchronize();
 
   cudaMemcpy(&h_select_count, d_select_count, sizeof(int),
@@ -190,9 +193,9 @@ int main(int argc, char **argv) {
 
   std::cout << "\nRunning SELECT revenue (price * quantity) with WHERE price > "
                "threshold:\n";
-  project_revenue<<<blocks, threads>>>(table.d_price, table.d_quantity,
-                                       d_revenue, d_revenue_count,
-                                       table.num_rows, threshold);
+  project_revenue<<<blocks, threads>>>(d_price, d_quantity, d_revenue,
+                                       d_revenue_count, table.num_rows,
+                                       threshold);
   cudaDeviceSynchronize();
 
   cudaMemcpy(&h_revenue_count, d_revenue_count, sizeof(int),
@@ -209,8 +212,8 @@ int main(int argc, char **argv) {
 
   std::cout << "\nRunning SELECT revenue and adjusted_price:\n";
   project_revenue_and_adjusted<<<blocks, threads>>>(
-      table.d_price, table.d_quantity, d_revenue_multi, d_adjusted_price,
-      d_multi_count, table.num_rows, threshold);
+      d_price, d_quantity, d_revenue_multi, d_adjusted_price, d_multi_count,
+      table.num_rows, threshold);
   cudaDeviceSynchronize();
 
   cudaMemcpy(&h_multi_count, d_multi_count, sizeof(int),
@@ -260,8 +263,7 @@ int main(int argc, char **argv) {
 
   // compile
   std::cout << "\n[ JIT Kernel Execution for Expression ]\n";
-  jit_compile_and_launch(expr_cuda, condition_cuda, table.d_price,
-                         table.d_quantity, d_jit_output, table.num_rows);
+  jit_compile_and_launch(expr_cuda, condition_cuda, table, d_jit_output);
 
   float *h_jit_output = new float[table.num_rows];
   cudaMemcpy(h_jit_output, d_jit_output, sizeof(float) * table.num_rows,
@@ -291,8 +293,9 @@ int main(int argc, char **argv) {
   cudaFree(d_price_filtered);
   cudaFree(d_quantity_filtered);
   cudaFree(d_count);
-  cudaFree(table.d_price);
-  cudaFree(table.d_quantity);
+  for (auto &col : table.columns) {
+    cudaFree(col.device_ptr);
+  }
 
   return 0;
 }


### PR DESCRIPTION
## Summary
- manage columns using a new `ColumnDesc` structure and `Table` registry
- infer column types when loading CSV data
- generalize JIT kernel interface to accept a table with arbitrary columns
- update main example to use dynamic column access

## Testing
- `g++ -std=c++17 -I include tests/test_expression.cpp src/expression.cpp -o expr_test && ./expr_test`
- `g++ -std=c++17 -I include tests/expression_tests.cpp src/expression.cpp -o expr_test2 && ./expr_test2`
- `cmake ..` *(fails: Failed to find nvcc)*
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_6845be9e50cc83289a5e6406e37c1120