### PR TITLE
Add additional expression unit tests

### DIFF
--- a/tests/precedence_tests.cpp
+++ b/tests/precedence_tests.cpp
@@ -1,0 +1,24 @@
+#include "expression.hpp"
+#include <cassert>
+#include <iostream>
+
+void test_precedence() {
+    auto tokens = tokenize("price + quantity * 2");
+    auto ast = parse_expression(tokens);
+    std::string code = ast->to_cuda_expr();
+    assert(code == "(price[idx] + (quantity[idx] * 2.0f))");
+}
+
+void test_parentheses() {
+    auto tokens = tokenize("(price + quantity) * 2");
+    auto ast = parse_expression(tokens);
+    std::string code = ast->to_cuda_expr();
+    assert(code == "((price[idx] + quantity[idx]) * 2.0f)");
+}
+
+int main() {
+    test_precedence();
+    test_parentheses();
+    std::cout << "All precedence tests passed\n";
+    return 0;
+}

--- a/tests/tokenizer_tests.cpp
+++ b/tests/tokenizer_tests.cpp
@@ -1,0 +1,38 @@
+#include "expression.hpp"
+#include <cassert>
+#include <iostream>
+#include <vector>
+
+void test_basic_tokenize() {
+    auto tokens = tokenize("price > 10");
+    assert(tokens.size() == 4);
+    assert(tokens[0].type == TokenType::Identifier && tokens[0].value == "price");
+    assert(tokens[1].type == TokenType::Operator && tokens[1].value == ">");
+    assert(tokens[2].type == TokenType::Number && tokens[2].value == "10");
+    assert(tokens[3].type == TokenType::End);
+}
+
+void test_parentheses_tokenize() {
+    auto tokens = tokenize("(price + 5) * quantity");
+    std::vector<TokenType> expected = {
+        TokenType::Operator,    // (
+        TokenType::Identifier,  // price
+        TokenType::Operator,    // +
+        TokenType::Number,      // 5
+        TokenType::Operator,    // )
+        TokenType::Operator,    // *
+        TokenType::Identifier,  // quantity
+        TokenType::End
+    };
+    assert(tokens.size() == expected.size());
+    for (size_t i = 0; i < expected.size(); ++i) {
+        assert(tokens[i].type == expected[i]);
+    }
+}
+
+int main() {
+    test_basic_tokenize();
+    test_parentheses_tokenize();
+    std::cout << "All tokenizer tests passed\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add tests covering tokenization edge cases
- test operator precedence and parentheses handling

## Testing
- `g++ -std=c++17 -I../include ../tests/test_expression.cpp ../src/expression.cpp -o test_expression`
- `./test_expression`
- `g++ -std=c++17 -I../include ../tests/expression_tests.cpp ../src/expression.cpp -o expression_tests`
- `./expression_tests`
- `g++ -std=c++17 -I../include ../tests/tokenizer_tests.cpp ../src/expression.cpp -o tokenizer_tests`
- `./tokenizer_tests`
- `g++ -std=c++17 -I../include ../tests/precedence_tests.cpp ../src/expression.cpp -o precedence_tests`
- `./precedence_tests`


------
https://chatgpt.com/codex/tasks/task_e_6845bed1f65c8328b2d0b715a7d8395b