### PR TITLE
Add basic CI workflow for building and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential cmake ninja-build nvidia-cuda-toolkit
+      - name: Configure
+        run: cmake -S . -B build -G "Unix Makefiles"
+      - name: Build
+        run: cmake --build build -j $(nproc)
+      - name: Run tests
+        run: |
+          cd build
+          ctest --output-on-failure

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ _deps
 CMakeUserPresets.json
 warpdb
 tests/expression_tests
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.18)
 
 project(WarpDB LANGUAGES CXX CUDA)
 
+enable_testing()
+
 set(CMAKE_CXX_STANDARD 17)
 
 find_package(CUDAToolkit REQUIRED)
@@ -27,4 +29,11 @@ add_executable(expression_test
 )
 
 add_test(NAME expression_test COMMAND expression_test)
+
+add_executable(expression_tests
+    tests/expression_tests.cpp
+    src/expression.cpp
+)
+
+add_test(NAME expression_tests COMMAND expression_tests)
 


### PR DESCRIPTION
## Summary
- enable CMake testing and add missing test target
- configure GitHub Actions workflow that builds the project with CUDA toolkit
  and runs the tests
- ignore build directory in git

## Testing
- `cmake .. && cmake --build . -j $(nproc) && ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6845beb7c4048328a2176f410d8e5857