### PR TITLE
Fix csv_loader.hpp struct definitions

### DIFF
--- a/include/csv_loader.hpp
+++ b/include/csv_loader.hpp
@@ -15,6 +15,7 @@ struct ColumnDesc {
   DataType type;
   void *device_ptr;
   int length;
+};
 
 struct ColumnStatsFloat {
   float min = 0.0f;
@@ -48,6 +49,7 @@ struct Table {
 
   int num_rows;
 
+  TableStats stats; // basic column statistics
 
   template <typename T>
   T *get_column_ptr(const std::string &name) const {
@@ -62,9 +64,6 @@ struct Table {
 Table load_csv_to_gpu(const std::string &filepath,
                       const std::vector<DataType> &schema = {});
 
-  TableStats stats; // basic column statistics
-};
-
 struct HostTable {
   std::vector<float> price;
   std::vector<int> quantity;
@@ -73,5 +72,4 @@ struct HostTable {
 
 HostTable load_csv_to_host(const std::string &filepath);
 Table upload_to_gpu(const HostTable &table);
-Table load_csv_to_gpu(const std::string &filepath);
 


### PR DESCRIPTION
## Summary
- correct struct boundaries in `csv_loader.hpp`
- move `TableStats` into `Table` and clean up function declarations

## Testing
- `g++ -std=c++17 -fsyntax-only include/csv_loader.hpp`
- `cmake -S . -B build` *(fails: Failed to find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6845c30826cc83289d440ca61fb84446