### PR TITLE
Fix missing #endif and main return

### DIFF
--- a/src/main.cu
+++ b/src/main.cu
@@ -415,7 +415,7 @@ int main(int argc, char **argv) {
   for (auto &col : table.columns) {
     cudaFree(col.device_ptr);
   }
-
+#endif
 
   return 0;
 }


### PR DESCRIPTION
## Summary
- close `#ifndef USE_ARROW` block properly
- ensure `main` ends with `return 0;`

## Testing
- `ctest --output-on-failure`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pywarpdb')*

------
https://chatgpt.com/codex/tasks/task_e_6845c30b925c83289dd86f00a2c7d0fb