### PR TITLE
Simplify JIT compilation API

### DIFF
--- a/include/jit.hpp
+++ b/include/jit.hpp
@@ -1,10 +1,10 @@
 #pragma once
 #include <string>
 
-#include "csv_loader.hpp"
-
+// Compile the given expression and optional condition using NVRTC and launch
+// the generated kernel. The kernel operates on the provided price and quantity
+// device arrays and writes the results to d_output.
 void jit_compile_and_launch(const std::string &expr_code,
                             const std::string &condition_code,
-                            const Table &table, float *d_output);
-                            float *d_price, int *d_quantity, float *d_output,
-                            int N, int device_id = 0);
+                            float *d_price, int *d_quantity,
+                            float *d_output, int N, int device_id = 0);


### PR DESCRIPTION
## Summary
- clean up jit API so callers pass device pointers directly
- remove old table based kernel generation logic

## Testing
- `cmake ..` *(fails: Failed to find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6845c309cad48328b6203d5caa64fe2e