### PR TITLE
Handle Arrow memory in WarpDB destructor

### DIFF
--- a/src/warpdb.cpp
+++ b/src/warpdb.cpp
@@ -9,8 +9,13 @@ WarpDB::WarpDB(const std::string &csv_path) {
 }
 
 WarpDB::~WarpDB() {
+#ifdef USE_ARROW
+    table_.d_price.reset();
+    table_.d_quantity.reset();
+#else
     cudaFree(table_.d_price);
     cudaFree(table_.d_quantity);
+#endif
 }
 
 std::vector<float> WarpDB::query(const std::string &expr) {


### PR DESCRIPTION
## Summary
- reset Arrow buffers in `WarpDB::~WarpDB` when Arrow is enabled
- keep existing `cudaFree` for non-Arrow builds

## Testing
- `cmake ..` *(fails: Failed to find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6845c4e01c4083288caa64d8f1c01eaa