### PR TITLE
Fix duplicate includes in arrow loader

### DIFF
--- a/src/arrow_loader.cpp
+++ b/src/arrow_loader.cpp
@@ -7,14 +7,12 @@
 #include <iostream>
 #include <sstream>
 #include <stdexcept>
-#include "arrow_loader.hpp"
 #include <arrow/api.h>
 #include <arrow/io/file.h>
 #include <arrow/ipc/api.h>
 #include <parquet/arrow/reader.h>
 #include <arrow/adapters/orc/adapter.h>
 #include <cuda_runtime.h>
-#include <iostream>
 
 #define CUDA_CHECK(err) \
   do { \


### PR DESCRIPTION
## Summary
- clean up duplicate headers in `arrow_loader.cpp`

## Testing
- `cmake ..` *(fails: Failed to find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6845c4dc78b083289353bd985157ac2c