### PR TITLE
Add default upload_to_gpu wrapper

### DIFF
--- a/include/csv_loader.hpp
+++ b/include/csv_loader.hpp
@@ -71,5 +71,7 @@ struct HostTable {
 };
 
 HostTable load_csv_to_host(const std::string &filepath);
+Table upload_to_gpu(const HostTable &table,
+                    const std::vector<DataType> &schema);
 Table upload_to_gpu(const HostTable &table);
 

--- a/src/csv_loader.cpp
+++ b/src/csv_loader.cpp
@@ -85,6 +85,8 @@ Table upload_to_gpu(const HostTable &host, const std::vector<DataType> &schema) 
   return table;
 }
 
+Table upload_to_gpu(const HostTable &host) { return upload_to_gpu(host, {}); }
+
 Table load_csv_to_gpu(const std::string &filepath, const std::vector<DataType> &schema) {
 #ifdef USE_ARROW
   if (schema.empty()) {


### PR DESCRIPTION
## Summary
- expose a missing overload for `upload_to_gpu`
- declare the overloads in the header

## Testing
- `cmake ..` *(fails: Failed to find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6845c4e207cc8328bc380102b6c1926f