### PR TITLE
Add JSON format loader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ include_directories(include)
 set(WARPDB_SRC
     src/main.cu
     src/csv_loader.cpp
+    src/json_loader.cpp
     src/arrow_loader.cpp
     src/expression.cpp
     src/jit.cpp
@@ -71,6 +72,7 @@ add_test(NAME query_parser_test COMMAND query_parser_test)
 add_library(warpdb_lib STATIC
     src/warpdb.cpp
     src/csv_loader.cpp
+    src/json_loader.cpp
     src/expression.cpp
     src/jit.cpp
 )

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ WarpDB is a GPU-accelerated SQL query engine that demonstrates how to leverage C
 - **Dynamic CUDA Kernel Compilation**: JIT-compile custom CUDA kernels at runtime based on user expressions
 - **Expression Parsing & Code Generation**: Parse SQL-like expressions and automatically generate optimized CUDA code
 - **CSV Data Loading**: Efficiently load data from CSV files directly to GPU memory
+- **JSON Data Loading**: Read newline-delimited JSON files
 - **Parquet/Arrow/ORC Loading**: Use Apache Arrow to ingest columnar formats
 - **CUDA-Based Data Filtering & Projection**: Filter and transform data in parallel on the GPU
 - **Arrow Columnar Format**: Optionally load data using Apache Arrow for zero-copy
@@ -23,6 +24,10 @@ WarpDB consists of the following main components:
 ### CSV Loader
 - Loads CSV data directly into GPU memory with minimal CPU intervention
 - Handles data type conversion and memory allocation
+
+### JSON Loader
+- Parses newline-delimited JSON records containing `price` and `quantity`
+- Uploads parsed columns to GPU memory
 
 
 ### Arrow Integration
@@ -105,7 +110,7 @@ You can also use WarpDB directly from Python if `pybind11` is available:
 ```python
 import pywarpdb
 
-db = pywarpdb.WarpDB("data/test.csv")
+db = pywarpdb.WarpDB("data/test.csv")  # or data/test.json
 result = db.query("price * quantity WHERE price > 10")
 print(result)
 ```
@@ -137,7 +142,8 @@ each device. Results are aggregated back on the host.
 ```
 ├── CMakeLists.txt          # CMake build configuration
 ├── data/                   # Sample data files
-│   └── test.csv            # Test data
+│   ├── test.csv            # Test data
+│   └── test.json           # JSON test data
 ├── include/                # Header files
 │   ├── csv_loader.hpp      # CSV loading interface
 │   ├── arrow_loader.hpp    # Parquet/Arrow/ORC loading interface
@@ -197,7 +203,7 @@ WarpDB implements several CUDA kernels:
 ## Limitations
 
 - Currently supports a limited subset of SQL functionality
-- Only supports simple CSV files with basic data types
+- Only supports simple CSV and JSON files with basic data types
 - No support for joins, aggregations, or complex SQL features yet
 - Limited error handling for malformed queries
 
@@ -205,7 +211,7 @@ WarpDB implements several CUDA kernels:
 
 - Support for more SQL features (JOINs, GROUP BY, ORDER BY)
 - Better error handling and query validation
-- Support for more data sources and formats
+- Additional data source support (e.g. Avro)
 - Query optimization based on data statistics
 - Multi-GPU support for larger datasets
 - Return results as Arrow buffers for easy sharing

--- a/data/test.json
+++ b/data/test.json
@@ -1,0 +1,4 @@
+{"price": 10.5, "quantity": 3}
+{"price": 20.0, "quantity": 4}
+{"price": 15.25, "quantity": 2}
+{"price": 30.0, "quantity": 5}

--- a/include/json_loader.hpp
+++ b/include/json_loader.hpp
@@ -1,0 +1,6 @@
+#pragma once
+#include <string>
+#include "csv_loader.hpp" // for HostTable and Table
+
+HostTable load_json_to_host(const std::string &filepath);
+Table load_json_to_gpu(const std::string &filepath);

--- a/include/warpdb.hpp
+++ b/include/warpdb.hpp
@@ -3,12 +3,13 @@
 #include <vector>
 
 #include "csv_loader.hpp"
+#include "json_loader.hpp"
 #include "expression.hpp"
 #include "jit.hpp"
 
 class WarpDB {
 public:
-    explicit WarpDB(const std::string &csv_path);
+    explicit WarpDB(const std::string &filepath);
     ~WarpDB();
 
     // Execute an expression with optional WHERE clause.

--- a/src/json_loader.cpp
+++ b/src/json_loader.cpp
@@ -1,0 +1,50 @@
+#include "json_loader.hpp"
+#include <cuda_runtime.h>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+
+#define CUDA_CHECK(err) \
+  do { \
+    if (err != cudaSuccess) { \
+      std::cerr << "CUDA Error: " << cudaGetErrorString(err) << "\n"; \
+      exit(1); \
+    } \
+  } while (0)
+
+HostTable load_json_to_host(const std::string &filepath) {
+  std::ifstream file(filepath);
+  if (!file.is_open()) {
+    std::cerr << "Failed to open file: " << filepath << std::endl;
+    throw std::runtime_error("Unable to open file");
+  }
+
+  HostTable host;
+  std::string line;
+  while (std::getline(file, line)) {
+    float price = 0.0f;
+    int quantity = 0;
+    // very simple JSON line parser assuming format {"price": X, "quantity": Y}
+    size_t p = line.find("\"price\"");
+    size_t q = line.find("\"quantity\"");
+    if (p == std::string::npos || q == std::string::npos)
+      continue;
+    p = line.find(':', p);
+    q = line.find(':', q);
+    if (p == std::string::npos || q == std::string::npos)
+      continue;
+    std::stringstream ss1(line.substr(p + 1));
+    ss1 >> price;
+    std::stringstream ss2(line.substr(q + 1));
+    ss2 >> quantity;
+    host.price.push_back(price);
+    host.quantity.push_back(quantity);
+  }
+  return host;
+}
+
+Table load_json_to_gpu(const std::string &filepath) {
+  HostTable host = load_json_to_host(filepath);
+  return upload_to_gpu(host);
+}

--- a/src/warpdb.cpp
+++ b/src/warpdb.cpp
@@ -4,8 +4,24 @@
 #include <cctype>
 #include <iostream>
 
-WarpDB::WarpDB(const std::string &csv_path) {
-    table_ = load_csv_to_gpu(csv_path);
+WarpDB::WarpDB(const std::string &filepath) {
+    auto dot = filepath.find_last_of('.');
+    std::string ext = dot == std::string::npos ? "" : filepath.substr(dot + 1);
+    for (auto &c : ext) c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+
+    if (ext == "csv") {
+        table_ = load_csv_to_gpu(filepath);
+    } else if (ext == "json") {
+        table_ = load_json_to_gpu(filepath);
+    } else if (ext == "parquet") {
+        table_ = load_parquet_to_gpu(filepath);
+    } else if (ext == "arrow" || ext == "feather") {
+        table_ = load_arrow_to_gpu(filepath);
+    } else if (ext == "orc") {
+        table_ = load_orc_to_gpu(filepath);
+    } else {
+        throw std::runtime_error("Unsupported file format: " + filepath);
+    }
 }
 
 WarpDB::~WarpDB() {


### PR DESCRIPTION
## Summary
- add `json_loader` to load newline-delimited JSON files
- detect file extension in `WarpDB` constructor
- document JSON support and update examples
- ship JSON sample data

## Testing
- `cmake ..` *(fails: Failed to find nvcc)*
- `ctest --test-dir build` *(no tests run)*

------
https://chatgpt.com/codex/tasks/task_e_6845c497bb2c8328a04d87d06d8a10e2