### PR TITLE
Add Arrow array query export

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ add_library(warpdb_lib STATIC
     src/csv_loader.cpp
     src/expression.cpp
     src/jit.cpp
+    src/arrow_utils.cpp
 )
 set_target_properties(warpdb_lib PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
 target_link_libraries(warpdb_lib PUBLIC CUDA::nvrtc CUDA::cuda_driver)

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ WarpDB is a GPU-accelerated SQL query engine that demonstrates how to leverage C
 - **CUDA-Based Data Filtering & Projection**: Filter and transform data in parallel on the GPU
 - **Arrow Columnar Format**: Optionally load data using Apache Arrow for zero-copy
   interoperability with Pandas, PyTorch, and Spark
+- **Arrow Results**: Retrieve query results as Arrow buffers for easy sharing
 - **User-Provided CUDA Functions**: Extend queries with functions defined in `custom.cu`
 - **Column Statistics & Optimizer**: Collect min/max/null counts for basic filter pushdown and kernel fusion
 
@@ -108,6 +109,11 @@ import pywarpdb
 db = pywarpdb.WarpDB("data/test.csv")
 result = db.query("price * quantity WHERE price > 10")
 print(result)
+
+# Export result as an Arrow array
+arr_capsule, schema_capsule = db.query_arrow("price * quantity")
+import pyarrow as pa
+arrow_arr = pa.Array._import_from_c(arr_capsule, schema_capsule)
 ```
 
 ### Example Queries
@@ -208,4 +214,3 @@ WarpDB implements several CUDA kernels:
 - Support for more data sources and formats
 - Query optimization based on data statistics
 - Multi-GPU support for larger datasets
-- Return results as Arrow buffers for easy sharing

--- a/bindings/python/pywarpdb.cpp
+++ b/bindings/python/pywarpdb.cpp
@@ -7,5 +7,25 @@ namespace py = pybind11;
 PYBIND11_MODULE(pywarpdb, m) {
     py::class_<WarpDB>(m, "WarpDB")
         .def(py::init<const std::string &>())
-        .def("query", &WarpDB::query);
+        .def("query", &WarpDB::query)
+        .def("query_arrow",
+             [](WarpDB &db, const std::string &expr, bool shared_memory) {
+                 auto arr = new ArrowArray();
+                 auto schema = new ArrowSchema();
+                 db.query_arrow(expr, arr, schema, shared_memory);
+                 py::capsule array_capsule(arr, [](void *ptr) {
+                     ArrowArray *arr = reinterpret_cast<ArrowArray *>(ptr);
+                     if (arr->release) arr->release(arr);
+                 });
+                 py::capsule schema_capsule(schema, [](void *ptr) {
+                     ArrowSchema *schema = reinterpret_cast<ArrowSchema *>(ptr);
+                     if (schema->release) schema->release(schema);
+                 });
+                 return py::make_tuple(array_capsule, schema_capsule);
+             },
+             py::arg("expr"), py::arg("shared_memory") = false,
+             R"pbdoc(Return result as Arrow C Data Interface capsules.
+
+The returned tuple contains (ArrowArray capsule, ArrowSchema capsule).
+Use pyarrow.Array._import_from_c(schema, array) to construct a PyArrow Array.)pbdoc");
 }

--- a/include/warpdb.hpp
+++ b/include/warpdb.hpp
@@ -5,6 +5,7 @@
 #include "csv_loader.hpp"
 #include "expression.hpp"
 #include "jit.hpp"
+#include "arrow_utils.hpp"
 
 class WarpDB {
 public:
@@ -14,6 +15,13 @@ public:
     // Execute an expression with optional WHERE clause.
     // Example: "price * quantity WHERE price > 10"
     std::vector<float> query(const std::string &expr);
+
+    // Execute a query and export the results as Arrow buffers.
+    // The ArrowArray and ArrowSchema must be provided by the caller.
+    // When use_shared_memory is true, the result buffer is created in
+    // POSIX shared memory so other processes can access it.
+    void query_arrow(const std::string &expr, ArrowArray *out_array,
+                     ArrowSchema *out_schema, bool use_shared_memory = false);
 
 private:
     Table table_;

--- a/src/warpdb.cpp
+++ b/src/warpdb.cpp
@@ -46,3 +46,10 @@ std::vector<float> WarpDB::query(const std::string &expr) {
     cudaFree(d_output);
     return result;
 }
+
+void WarpDB::query_arrow(const std::string &expr, ArrowArray *out_array,
+                         ArrowSchema *out_schema, bool use_shared_memory) {
+    auto result = query(expr);
+    export_to_arrow(result.data(), static_cast<int64_t>(result.size()),
+                    use_shared_memory, out_array, out_schema);
+}


### PR DESCRIPTION
## Summary
- allow returning query results in Arrow buffers
- expose Arrow result export in Python bindings
- document new feature

## Testing
- `cmake ..` *(fails: Failed to find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6845c4b15da8832896a66a60e540cc79