### PR TITLE
Add streaming multi-GPU support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ WarpDB is a GPU-accelerated SQL query engine that demonstrates how to leverage C
   interoperability with Pandas, PyTorch, and Spark
 - **User-Provided CUDA Functions**: Extend queries with functions defined in `custom.cu`
 - **Column Statistics & Optimizer**: Collect min/max/null counts for basic filter pushdown and kernel fusion
+- **Multi-GPU Execution**: Stream large CSV files across multiple GPUs
 
 
 ## Architecture
@@ -128,9 +129,11 @@ print(result)
 
 ### Multi-GPU Example
 
-WarpDB includes a helper `run_multi_gpu_jit` demonstrating how to split the
-input table across available GPUs and execute the same JIT-compiled kernel on
-each device. Results are aggregated back on the host.
+WarpDB includes helpers `run_multi_gpu_jit` and `run_multi_gpu_jit_large`
+demonstrating how to split the input table across available GPUs and execute the
+same JIT-compiled kernel on each device. The `run_multi_gpu_jit_large` variant
+streams the CSV file in chunks, enabling processing of datasets larger than a
+single GPU's memory. Results are aggregated back on the host.
 
 ## Project Structure
 
@@ -207,5 +210,4 @@ WarpDB implements several CUDA kernels:
 - Better error handling and query validation
 - Support for more data sources and formats
 - Query optimization based on data statistics
-- Multi-GPU support for larger datasets
 - Return results as Arrow buffers for easy sharing

--- a/include/csv_loader.hpp
+++ b/include/csv_loader.hpp
@@ -73,3 +73,7 @@ struct HostTable {
 HostTable load_csv_to_host(const std::string &filepath);
 Table upload_to_gpu(const HostTable &table);
 
+// Load at most `max_rows` CSV rows from an open input stream. `finished`
+// will be set to true when no more rows are available.
+HostTable load_csv_chunk(std::istream &stream, int max_rows, bool &finished);
+

--- a/src/csv_loader.cpp
+++ b/src/csv_loader.cpp
@@ -103,3 +103,31 @@ Table load_csv_to_gpu(const std::string &filepath, const std::vector<DataType> &
 Table load_csv_to_gpu(const std::string &filepath) {
   return load_csv_to_gpu(filepath, {});
 }
+
+HostTable load_csv_chunk(std::istream &stream, int max_rows, bool &finished) {
+  std::vector<float> prices;
+  std::vector<int> quantities;
+  prices.reserve(max_rows);
+  quantities.reserve(max_rows);
+
+  std::string line;
+  int count = 0;
+  while (count < max_rows && std::getline(stream, line)) {
+    if (line.empty())
+      continue;
+    std::istringstream ss(line);
+    std::string price_str, qty_str;
+    std::getline(ss, price_str, ',');
+    std::getline(ss, qty_str, ',');
+    prices.push_back(std::stof(price_str));
+    quantities.push_back(std::stoi(qty_str));
+    ++count;
+  }
+
+  finished = !stream.good();
+
+  HostTable chunk;
+  chunk.price = std::move(prices);
+  chunk.quantity = std::move(quantities);
+  return chunk;
+}

--- a/src/main.cu
+++ b/src/main.cu
@@ -7,19 +7,18 @@
 #include "jit.hpp"
 #include "arrow_utils.hpp"
 #include "optimizer.hpp"
-
-// Simple multi-GPU execution of a JIT compiled expression.
-// Splits the input table across all available devices and aggregates the output.
-void run_multi_gpu_jit(const std::string &expr_cuda,
-                       const std::string &cond_cuda) {
-  HostTable host = load_csv_to_host("data/test.csv");
-
+#include <fstream>
+// Execute a JIT compiled expression across all available GPUs for the provided
+// host table chunk. Returns the aggregated results.
+std::vector<float> run_multi_gpu_jit_host(const HostTable &host,
+                                          const std::string &expr_cuda,
+                                          const std::string &cond_cuda) {
   int device_count = 0;
   cudaGetDeviceCount(&device_count);
   if (device_count < 2) {
     std::cout << "Only " << device_count
               << " GPU detected. Skipping multi-device example.\n";
-    return;
+    return {};
   }
 
   int N = host.num_rows();
@@ -53,10 +52,50 @@ void run_multi_gpu_jit(const std::string &expr_cuda,
     cudaFree(dtab.d_quantity);
   }
 
-  for (int i = 0; i < N; ++i) {
+  return results;
+}
+
+// Convenience wrapper that loads the sample CSV and prints the results.
+void run_multi_gpu_jit(const std::string &expr_cuda,
+                       const std::string &cond_cuda) {
+  HostTable host = load_csv_to_host("data/test.csv");
+  auto results = run_multi_gpu_jit_host(host, expr_cuda, cond_cuda);
+  for (size_t i = 0; i < results.size(); ++i) {
     std::cout << "MultiGPU Result[" << i << "] = " << results[i] << "\n";
   }
 }
+
+// Process a CSV file in chunks using all GPUs and aggregate results.
+void run_multi_gpu_jit_large(const std::string &csv_path,
+                             const std::string &expr_cuda,
+                             const std::string &cond_cuda,
+                             int rows_per_chunk = 1000000) {
+  std::ifstream file(csv_path);
+  if (!file.is_open()) {
+    std::cerr << "Failed to open file: " << csv_path << "\n";
+    return;
+  }
+
+  std::string header;
+  std::getline(file, header);
+
+  bool finished = false;
+  std::vector<float> all_results;
+  while (!finished) {
+    HostTable chunk = load_csv_chunk(file, rows_per_chunk, finished);
+    if (chunk.num_rows() == 0)
+      break;
+    auto part = run_multi_gpu_jit_host(chunk, expr_cuda, cond_cuda);
+    all_results.insert(all_results.end(), part.begin(), part.end());
+  }
+
+  for (size_t i = 0; i < all_results.size(); ++i) {
+    std::cout << "Large MultiGPU Result[" << i << "] = " << all_results[i]
+              << "\n";
+  }
+}
+
+
 
 __global__ void print_first_few(float *price, int *quantity, int N) {
   int idx = threadIdx.x;
@@ -385,6 +424,9 @@ int main(int argc, char **argv) {
 
   std::cout << "\n[ Multi-GPU JIT Example ]\n";
   run_multi_gpu_jit(expr_cuda, condition_cuda);
+
+  std::cout << "\n[ Large Multi-GPU Example ]\n";
+  run_multi_gpu_jit_large("data/test.csv", expr_cuda, condition_cuda, 1024);
 
 
   delete[] h_jit_output;


### PR DESCRIPTION
## Summary
- add `load_csv_chunk` helper for reading partial CSV data
- implement `run_multi_gpu_jit_host` and `run_multi_gpu_jit_large`
- demonstrate large dataset processing in `main.cu`
- document multi-GPU streaming in README

## Testing
- `cmake ..` *(fails: Failed to find nvcc)*
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_6845c4a857248328ab44a4083ba6ef18