### PR TITLE
Fix arrow loader duplication in build list

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,6 @@ include_directories(include)
 set(WARPDB_SRC
     src/main.cu
     src/csv_loader.cpp
-    src/arrow_loader.cpp
     src/expression.cpp
     src/jit.cpp
     src/arrow_utils.cpp


### PR DESCRIPTION
## Summary
- avoid listing `arrow_loader.cpp` twice in `WARPDB_SRC`

## Testing
- `cmake -S . -B build`

------
https://chatgpt.com/codex/tasks/task_e_6845c4de40dc8328b9883a044a2ff4c9