### PR TITLE
Remove old csv constructor

### DIFF
--- a/src/warpdb.cpp
+++ b/src/warpdb.cpp
@@ -6,14 +6,10 @@
 
 #include <map>
 #include <utility>
-
-WarpDB::WarpDB(const std::string &csv_path) {
-    host_table_ = load_csv_to_host(csv_path);
-    table_ = upload_to_gpu(host_table_);
-
 #include <stdexcept>
 #include <unordered_set>
 #include <memory>
+
 
 namespace {
 // Recursively validate that all variable references exist in the table.


### PR DESCRIPTION
## Summary
- clean up WarpDB implementation
- drop obsolete csv-only constructor
- group standard includes at the top of `warpdb.cpp`

## Testing
- `cmake ..` *(fails: Failed to find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6845c8cdd1e88328aea0796642566d95