### PR TITLE
Fix closing brace in query_sql

### DIFF
--- a/src/warpdb.cpp
+++ b/src/warpdb.cpp
@@ -6,11 +6,7 @@
 
 #include <map>
 #include <utility>
-
-WarpDB::WarpDB(const std::string &csv_path) {
-    host_table_ = load_csv_to_host(csv_path);
-    table_ = upload_to_gpu(host_table_);
-
+#include "arrow_loader.hpp"
 #include <stdexcept>
 #include <unordered_set>
 #include <memory>
@@ -240,6 +236,7 @@ std::vector<float> WarpDB::query_sql(const std::string &sql) {
     }
 
     return result;
+}
 
 void WarpDB::query_arrow(const std::string &expr, ArrowArray *out_array,
                          ArrowSchema *out_schema, bool use_shared_memory) {


### PR DESCRIPTION
## Summary
- include arrow loader header
- remove duplicate constructor definition
- close `WarpDB::query_sql` properly

## Testing
- `g++ -std=c++17 -Iinclude -c src/warpdb.cpp`

------
https://chatgpt.com/codex/tasks/task_e_6845c8cc59f48328bcd9413551adafbf