### PR TITLE
Make Arrow support optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,12 +22,12 @@ set(WARPDB_SRC
     src/main.cu
     src/csv_loader.cpp
     src/json_loader.cpp
-    src/arrow_loader.cpp
     src/expression.cpp
     src/jit.cpp
     src/arrow_utils.cpp
     src/optimizer.cpp
 )
+
 
 if(Arrow_FOUND)
     list(APPEND WARPDB_SRC src/arrow_loader.cpp)

--- a/src/arrow_loader.cpp
+++ b/src/arrow_loader.cpp
@@ -66,7 +66,6 @@ ArrowTable load_csv_arrow(const std::string &filepath) {
 
     return {d_price, d_quantity, num_rows};
 }
-#endif
 
 
 namespace {
@@ -140,3 +139,5 @@ Table load_orc_to_gpu(const std::string &filepath) {
   ARROW_ASSIGN_OR_RAISE(table, arrow::adapters::orc::ORCFileReader::Read(*infile));
   return table_from_arrow(table);
 }
+
+#endif // USE_ARROW


### PR DESCRIPTION
## Summary
- remove `src/arrow_loader.cpp` from the default `WARPDB_SRC` list
- compile `arrow_loader.cpp` only when Arrow is found
- guard the entire `arrow_loader.cpp` implementation with `#ifdef USE_ARROW`

## Testing
- `cmake ..` *(fails: Failed to find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6845c8cb3e548328ba5dd5666e895c59