### PR TITLE
Update README testing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ make
 When `pybind11` is available a `pywarpdb` Python module is generated in the
 build directory alongside the C++ binaries.
 
+## Testing
+
+Run `ctest` from the `build` directory to execute the project's tests. Some
+tests rely on CUDA and optional libraries like Arrow or pybind11.
+
 ## Usage
 
 ```bash


### PR DESCRIPTION
## Summary
- describe running `ctest` from the build directory
- note CUDA and optional Arrow/pybind11 test requirements

## Testing
- `cmake ..` *(fails: Failed to find nvcc)*
- `ctest` *(fails: No test configuration file found)*


------
https://chatgpt.com/codex/tasks/task_e_6845cd00a3688328a2d8ce9fdf1d2687