### PR TITLE
Add Arrow optional build support and compile check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,3 +102,9 @@ if(pybind11_FOUND)
     pybind11_add_module(pywarpdb bindings/python/pywarpdb.cpp)
     target_link_libraries(pywarpdb PRIVATE warpdb_lib)
 endif()
+
+# Test building without Apache Arrow available
+add_test(
+    NAME no_arrow_build
+    COMMAND bash ${CMAKE_SOURCE_DIR}/tests/build_no_arrow.sh
+)

--- a/include/arrow_loader.hpp
+++ b/include/arrow_loader.hpp
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <string>
+#include <stdexcept>
 #ifdef USE_ARROW
 #include <arrow/api.h>
 #include <arrow/cuda/api.h>
@@ -17,12 +18,23 @@ struct ArrowTable {
 
 #ifdef USE_ARROW
 ArrowTable load_csv_arrow(const std::string &filepath);
-#endif
-
-#include <string>
-#include "csv_loader.hpp" // for Table structure
-
 Table load_parquet_to_gpu(const std::string &filepath);
 Table load_arrow_to_gpu(const std::string &filepath);
 Table load_orc_to_gpu(const std::string &filepath);
+#else
+inline ArrowTable load_csv_arrow(const std::string &) {
+    throw std::runtime_error("Arrow support not available");
+}
+inline Table load_parquet_to_gpu(const std::string &) {
+    throw std::runtime_error("Arrow support not available");
+}
+inline Table load_arrow_to_gpu(const std::string &) {
+    throw std::runtime_error("Arrow support not available");
+}
+inline Table load_orc_to_gpu(const std::string &) {
+    throw std::runtime_error("Arrow support not available");
+}
+#endif
+
+#include "csv_loader.hpp" // for Table structure
 

--- a/src/warpdb.cpp
+++ b/src/warpdb.cpp
@@ -51,12 +51,19 @@ WarpDB::WarpDB(const std::string &filepath) {
         table_ = load_csv_to_gpu(filepath);
     } else if (ext == "json") {
         table_ = load_json_to_gpu(filepath);
+#ifdef USE_ARROW
     } else if (ext == "parquet") {
         table_ = load_parquet_to_gpu(filepath);
     } else if (ext == "arrow" || ext == "feather") {
         table_ = load_arrow_to_gpu(filepath);
     } else if (ext == "orc") {
         table_ = load_orc_to_gpu(filepath);
+#else
+    } else if (ext == "parquet" || ext == "arrow" || ext == "feather" ||
+               ext == "orc") {
+        throw std::runtime_error(
+            "Arrow support is not compiled into WarpDB");
+#endif
     } else {
         throw std::runtime_error("Unsupported file format: " + filepath);
     }

--- a/tests/build_no_arrow.sh
+++ b/tests/build_no_arrow.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e
+cd "$(dirname "$0")/.."
+build_dir=build-no-arrow
+rm -rf "$build_dir"
+cmake -S . -B "$build_dir" -DCMAKE_DISABLE_FIND_PACKAGE_Arrow=ON >/dev/null
+cmake --build "$build_dir" --target warpdb >/dev/null


### PR DESCRIPTION
## Summary
- handle Arrow-only file formats with USE_ARROW in WarpDB::WarpDB
- provide stub implementations for Arrow loading helpers when Arrow is disabled
- add script and CMake test to build without Arrow

## Testing
- `cmake -S . -B build` *(fails: Failed to find nvcc)*
- `cmake -S . -B build_no_arrow -DCMAKE_DISABLE_FIND_PACKAGE_Arrow=ON` *(fails: Failed to find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6845ccff40388328a7274ab825771213