### PR TITLE
Fix build issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,8 @@ set(WARPDB_SRC
 
 if(Arrow_FOUND)
     list(APPEND WARPDB_SRC src/arrow_loader.cpp)
+else()
+    list(APPEND WARPDB_SRC src/arrow_loader_stub.cpp)
 endif()
 
 add_executable(warpdb ${WARPDB_SRC})
@@ -41,9 +43,9 @@ set_target_properties(warpdb PROPERTIES
 
 
 if(Arrow_FOUND)
-    target_link_libraries(warpdb PRIVATE CUDA::nvrtc CUDA::cuda_driver ${Arrow_LIBRARIES})
+    target_link_libraries(warpdb PRIVATE CUDA::cudart CUDA::nvrtc CUDA::cuda_driver ${Arrow_LIBRARIES})
 else()
-    target_link_libraries(warpdb PRIVATE CUDA::nvrtc CUDA::cuda_driver)
+    target_link_libraries(warpdb PRIVATE CUDA::cudart CUDA::nvrtc CUDA::cuda_driver)
 endif()
 
 add_executable(expression_test
@@ -69,13 +71,11 @@ add_executable(query_parser_test
 
 add_test(NAME query_parser_test COMMAND query_parser_test)
 
+
 add_executable(sql_features_test
     tests/sql_features_test.cpp
-    src/warpdb.cpp
-    src/csv_loader.cpp
-    src/expression.cpp
-    src/jit.cpp
 )
+target_link_libraries(sql_features_test PRIVATE warpdb_lib)
 
 add_test(NAME sql_features_test COMMAND sql_features_test)
 
@@ -83,7 +83,7 @@ add_executable(jit_error_test
     tests/jit_error_test.cpp
     src/jit.cpp
 )
-target_link_libraries(jit_error_test PRIVATE CUDA::nvrtc CUDA::cuda_driver)
+target_link_libraries(jit_error_test PRIVATE CUDA::cudart CUDA::nvrtc CUDA::cuda_driver)
 add_test(NAME jit_error_test COMMAND jit_error_test)
 
 add_library(warpdb_lib STATIC
@@ -94,8 +94,13 @@ add_library(warpdb_lib STATIC
     src/jit.cpp
     src/arrow_utils.cpp
 )
+if(Arrow_FOUND)
+    target_sources(warpdb_lib PRIVATE src/arrow_loader.cpp)
+else()
+    target_sources(warpdb_lib PRIVATE src/arrow_loader_stub.cpp)
+endif()
 set_target_properties(warpdb_lib PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
-target_link_libraries(warpdb_lib PUBLIC CUDA::nvrtc CUDA::cuda_driver)
+target_link_libraries(warpdb_lib PUBLIC CUDA::cudart CUDA::nvrtc CUDA::cuda_driver)
 
 find_package(pybind11 CONFIG QUIET)
 if(pybind11_FOUND)

--- a/src/arrow_loader_stub.cpp
+++ b/src/arrow_loader_stub.cpp
@@ -1,0 +1,16 @@
+#include "arrow_loader.hpp"
+#include <stdexcept>
+
+#ifndef USE_ARROW
+Table load_parquet_to_gpu(const std::string &filepath) {
+    throw std::runtime_error("Arrow support not enabled");
+}
+
+Table load_arrow_to_gpu(const std::string &filepath) {
+    throw std::runtime_error("Arrow support not enabled");
+}
+
+Table load_orc_to_gpu(const std::string &filepath) {
+    throw std::runtime_error("Arrow support not enabled");
+}
+#endif

--- a/src/main.cu
+++ b/src/main.cu
@@ -393,8 +393,8 @@ int main(int argc, char **argv) {
   auto ast = parse_expression(tokens);
   std::cout << "\nParsed Expression (CUDA):\n";
 
-  std::string cuda_expr = ast->to_cuda_expr();
-  std::cout << cuda_expr << "\n";
+  std::string expr_cuda = ast->to_cuda_expr();
+  std::cout << expr_cuda << "\n";
 
   // compile
   std::cout << "\n[ JIT Kernel Execution for Expression ]\n";


### PR DESCRIPTION
## Summary
- fix variable name in main CUDA source
- add arrow loader stub for non-Arrow builds
- link CUDA runtime to targets and add arrow loader sources
- link sql_features_test against warpdb library

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure` *(fails: sql_features_test, jit_error_test)*

------
https://chatgpt.com/codex/tasks/task_e_6845cc3474f883289834cb988340b8b4