### PR TITLE
Add logical AND/OR operators

### DIFF
--- a/include/expression.hpp
+++ b/include/expression.hpp
@@ -79,6 +79,8 @@ struct FunctionCallNode : public ASTNode {
 
 // Entry point
 ASTNodePtr parse_expression(const std::vector<Token> &tokens);
+ASTNodePtr parse_logical_and(const std::vector<Token> &tokens);
+ASTNodePtr parse_logical_or(const std::vector<Token> &tokens);
 enum class AggregationType { Sum, Avg, Count, Min, Max };
 
 struct AggregationNode : public ASTNode {

--- a/src/expression.cpp
+++ b/src/expression.cpp
@@ -26,7 +26,8 @@ std::vector<Token> tokenize(const std::string &input) {
       static const std::unordered_set<std::string> keywords = {
           "SELECT",   "FROM",  "WHERE", "JOIN", "ON",  "GROUP",
           "BY",       "ORDER", "ASC",  "DESC", "SUM", "AVG",
-          "COUNT",    "MIN",   "MAX",  "OVER", "PARTITION"};
+          "COUNT",    "MIN",   "MAX",  "OVER", "PARTITION",
+          "AND",      "OR"};
       if (keywords.count(upper)) {
         tokens.push_back({TokenType::Keyword, upper});
       } else {
@@ -84,6 +85,8 @@ bool match(const std::string &op) {
 // Forward declarations
 ASTNodePtr parse_term();
 ASTNodePtr parse_factor();
+ASTNodePtr parse_logical_or_internal();
+ASTNodePtr parse_logical_and_internal();
 
 // Parses: expr = term ( ("+"|"-") term )*
 ASTNodePtr parse_expression_internal() {
@@ -106,6 +109,30 @@ ASTNodePtr parse_comparison() {
     ASTNodePtr right = parse_expression_internal();
     node =
         std::make_unique<BinaryOpNode>(op, std::move(node), std::move(right));
+  }
+  return node;
+}
+
+// Parses: logical_and = comparison (AND comparison)*
+ASTNodePtr parse_logical_and_internal() {
+  ASTNodePtr node = parse_comparison();
+  while (peek().type == TokenType::Keyword && peek().value == "AND") {
+    advance();
+    ASTNodePtr right = parse_comparison();
+    node = std::make_unique<BinaryOpNode>("&&", std::move(node),
+                                          std::move(right));
+  }
+  return node;
+}
+
+// Parses: logical_or = logical_and (OR logical_and)*
+ASTNodePtr parse_logical_or_internal() {
+  ASTNodePtr node = parse_logical_and_internal();
+  while (peek().type == TokenType::Keyword && peek().value == "OR") {
+    advance();
+    ASTNodePtr right = parse_logical_and_internal();
+    node = std::make_unique<BinaryOpNode>("||", std::move(node),
+                                          std::move(right));
   }
   return node;
 }
@@ -158,12 +185,32 @@ ASTNodePtr parse_expression(const std::vector<Token> &tokens) {
   current = 0;
   toks = tokens;
 
-  ASTNodePtr node = parse_comparison();
+  ASTNodePtr node = parse_logical_or_internal();
   if (peek().type != TokenType::End) {
     throw std::runtime_error("Unexpected tokens remaining: " + peek().value);
   }
   return node;
 
+}
+
+ASTNodePtr parse_logical_and(const std::vector<Token> &tokens) {
+  current = 0;
+  toks = tokens;
+  ASTNodePtr node = parse_logical_and_internal();
+  if (peek().type != TokenType::End) {
+    throw std::runtime_error("Unexpected tokens remaining: " + peek().value);
+  }
+  return node;
+}
+
+ASTNodePtr parse_logical_or(const std::vector<Token> &tokens) {
+  current = 0;
+  toks = tokens;
+  ASTNodePtr node = parse_logical_or_internal();
+  if (peek().type != TokenType::End) {
+    throw std::runtime_error("Unexpected tokens remaining: " + peek().value);
+  }
+  return node;
 }
 
 QueryAST parse_query(const std::vector<Token> &tokens) {

--- a/tests/test_expression.cpp
+++ b/tests/test_expression.cpp
@@ -21,6 +21,17 @@ int main() {
     std::string code3 = ast3->to_cuda_expr();
     assert(code3 == "discount(price[idx], 0.9f)");
 
+    // logical AND/OR
+    auto tokens4 = tokenize("price > 10 AND quantity < 5");
+    auto ast4 = parse_expression(tokens4);
+    std::string code4 = ast4->to_cuda_expr();
+    assert(code4 == "((price[idx] > 10.0f) && (quantity[idx] < 5.0f))");
+
+    auto tokens5 = tokenize("price > 10 OR quantity < 5");
+    auto ast5 = parse_expression(tokens5);
+    std::string code5 = ast5->to_cuda_expr();
+    assert(code5 == "((price[idx] > 10.0f) || (quantity[idx] < 5.0f))");
+
     std::cout << "All parser tests passed\n";
     return 0;
 }

--- a/tests/tokenizer_tests.cpp
+++ b/tests/tokenizer_tests.cpp
@@ -30,9 +30,21 @@ void test_parentheses_tokenize() {
     }
 }
 
+void test_logical_keywords() {
+    auto tokens = tokenize("price > 10 AND quantity < 5");
+    bool found_and = false;
+    bool found_or = false;
+    for (const auto &t : tokens) {
+        if (t.type == TokenType::Keyword && t.value == "AND") found_and = true;
+        if (t.type == TokenType::Keyword && t.value == "OR") found_or = true;
+    }
+    assert(found_and && !found_or);
+}
+
 int main() {
     test_basic_tokenize();
     test_parentheses_tokenize();
+    test_logical_keywords();
     std::cout << "All tokenizer tests passed\n";
     return 0;
 }


### PR DESCRIPTION
## Summary
- extend tokenizer keywords with `AND` and `OR`
- add logical `AND`/`OR` parsing functions with proper precedence
- expose new parsing functions in the header
- test logical operators in expression and tokenizer tests

## Testing
- `g++ -std=c++17 -I include tests/test_expression.cpp src/expression.cpp -o expr_test && ./expr_test`
- `g++ -std=c++17 -I include tests/tokenizer_tests.cpp src/expression.cpp -o tok_test && ./tok_test`
- `g++ -std=c++17 -I include tests/precedence_tests.cpp src/expression.cpp -o prec_test && ./prec_test`

------
https://chatgpt.com/codex/tasks/task_e_6845ccfb903c8328ac71b7ea018ef304