### PR TITLE
Add LIMIT clause support

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ arrow_arr = pa.Array._import_from_c(arr_capsule, schema_capsule)
 
 # Use the SQL helper for GROUP BY
 ./warpdb "SELECT SUM(price) FROM test GROUP BY quantity"
+# Limit results after sorting
+./warpdb "SELECT price FROM test ORDER BY price DESC LIMIT 5"
 ```
 
 ### Multi-GPU Example
@@ -230,14 +232,14 @@ The project has recently gained several improvements:
 
 - Currently supports a limited subset of SQL functionality
 - Only supports simple CSV files with basic data types
-- Basic support for joins, aggregations, and ordering
+- Basic support for joins, aggregations, ordering, and LIMIT clauses
 - Limited error handling for malformed queries
 - Loading Parquet/Arrow/ORC files requires Apache Arrow
 - Building the Python module requires `pybind11`
 
 ## Future Improvements
 
-- Extend SQL support beyond the basic JOIN/GROUP BY/ORDER BY implementation
+- Continue extending SQL support beyond JOIN/GROUP BY/ORDER BY and LIMIT
 - Better error handling and query validation
 - Additional data source support (e.g. Avro)
 - Multi-GPU support for larger datasets

--- a/include/expression.hpp
+++ b/include/expression.hpp
@@ -95,6 +95,10 @@ struct OrderByClause {
   bool ascending;
 };
 
+struct LimitClause {
+  int count;
+};
+
 struct WindowFunctionNode : public ASTNode {
   AggregationType agg;
   ASTNodePtr expr;
@@ -122,6 +126,7 @@ struct QueryAST {
   std::optional<ASTNodePtr> where;
   std::optional<GroupByClause> group_by;
   std::optional<OrderByClause> order_by;
+  std::optional<LimitClause> limit;
 };
 
 QueryAST parse_query(const std::vector<Token> &tokens);

--- a/src/expression.cpp
+++ b/src/expression.cpp
@@ -25,8 +25,8 @@ std::vector<Token> tokenize(const std::string &input) {
         c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
       static const std::unordered_set<std::string> keywords = {
           "SELECT",   "FROM",  "WHERE", "JOIN", "ON",  "GROUP",
-          "BY",       "ORDER", "ASC",  "DESC", "SUM", "AVG",
-          "COUNT",    "MIN",   "MAX",  "OVER", "PARTITION"};
+          "BY",       "ORDER", "ASC",  "DESC", "LIMIT", "SUM",
+          "AVG",      "COUNT", "MIN",  "MAX",  "OVER", "PARTITION"};
       if (keywords.count(upper)) {
         tokens.push_back({TokenType::Keyword, upper});
       } else {
@@ -327,6 +327,16 @@ QueryAST parse_query(const std::vector<Token> &tokens) {
       pos++;
     }
     query.order_by = std::move(ob);
+  }
+
+  if (pos < tokens.size() && tokens[pos].type == TokenType::Keyword &&
+      tokens[pos].value == "LIMIT") {
+    pos++;
+    if (pos >= tokens.size() || tokens[pos].type != TokenType::Number)
+      throw std::runtime_error("Expected numeric value after LIMIT");
+    LimitClause lc{std::stoi(tokens[pos].value)};
+    pos++;
+    query.limit = lc;
   }
 
   return query;

--- a/src/main.cu
+++ b/src/main.cu
@@ -399,7 +399,7 @@ int main(int argc, char **argv) {
   // compile
   std::cout << "\n[ JIT Kernel Execution for Expression ]\n";
 
-  jit_compile_and_launch(expr_cuda, condition_cuda,
+  jit_compile_and_launch(cuda_expr, condition_cuda,
 #ifdef USE_ARROW
                          reinterpret_cast<float *>(table.d_price->mutable_data()),
                          reinterpret_cast<int *>(table.d_quantity->mutable_data()),
@@ -425,10 +425,10 @@ int main(int argc, char **argv) {
   schema.release(&schema);
 
   std::cout << "\n[ Multi-GPU JIT Example ]\n";
-  run_multi_gpu_jit(expr_cuda, condition_cuda);
+  run_multi_gpu_jit(cuda_expr, condition_cuda);
 
   std::cout << "\n[ Large Multi-GPU Example ]\n";
-  run_multi_gpu_jit_large("data/test.csv", expr_cuda, condition_cuda, 1024);
+  run_multi_gpu_jit_large("data/test.csv", cuda_expr, condition_cuda, 1024);
 
 
   delete[] h_jit_output;

--- a/src/warpdb.cpp
+++ b/src/warpdb.cpp
@@ -236,6 +236,11 @@ std::vector<float> WarpDB::query_sql(const std::string &sql) {
         for (const auto &kv : keyed) result.push_back(kv.second);
     }
 
+    if (ast.limit) {
+        if (static_cast<size_t>(ast.limit->count) < result.size())
+            result.resize(ast.limit->count);
+    }
+
     return result;
 }
 

--- a/tests/query_parser_test.cpp
+++ b/tests/query_parser_test.cpp
@@ -3,7 +3,7 @@
 #include <iostream>
 
 int main() {
-    std::string q = "SELECT SUM(price), quantity FROM sales JOIN items ON sales.id = items.id WHERE price > 10 GROUP BY quantity ORDER BY price DESC";
+    std::string q = "SELECT SUM(price), quantity FROM sales JOIN items ON sales.id = items.id WHERE price > 10 GROUP BY quantity ORDER BY price DESC LIMIT 5";
     auto tokens = tokenize(q);
     QueryAST ast = parse_query(tokens);
     assert(ast.select_list.size() == 2);
@@ -11,6 +11,7 @@ int main() {
     assert(ast.where.has_value());
     assert(ast.group_by.has_value());
     assert(ast.order_by.has_value());
+    assert(ast.limit.has_value());
     std::cout << "Query parse test passed\n";
     return 0;
 }

--- a/tests/sql_features_test.cpp
+++ b/tests/sql_features_test.cpp
@@ -6,5 +6,8 @@ int main(){
     WarpDB db("data/test.csv");
     auto res = db.query_sql("SELECT SUM(price) FROM test GROUP BY quantity ORDER BY quantity ASC");
     std::cout << "rows " << res.size() << "\n";
+
+    auto limited = db.query_sql("SELECT price FROM test ORDER BY price DESC LIMIT 2");
+    assert(limited.size() == 2);
     return 0;
 }


### PR DESCRIPTION
## Summary
- extend SQL query parser with LIMIT
- handle LIMIT during execution
- update README with LIMIT example
- validate LIMIT in parser tests
- test query_sql LIMIT functionality
- fix a variable name in main.cu

## Testing
- `cmake ..`
- `make -j4` *(fails: fatal error: stdlib.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6845cc5d4a948328b2b616f2ac527a09