### PR TITLE
Add optional data file argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,10 @@ build directory alongside the C++ binaries.
 ## Usage
 
 ```bash
-./warpdb "query_expression [WHERE condition]"
+./warpdb "query_expression [WHERE condition]" [data_file]
 ```
+
+If `data_file` is omitted, WarpDB loads `data/test.csv` by default.
 
 
 ### Custom CUDA Functions
@@ -149,9 +151,10 @@ arrow_arr = pa.Array._import_from_c(arr_capsule, schema_capsule)
 
 WarpDB includes helpers `run_multi_gpu_jit` and `run_multi_gpu_jit_large`
 demonstrating how to split the input table across available GPUs and execute the
-same JIT-compiled kernel on each device. The `run_multi_gpu_jit_large` variant
-streams the CSV file in chunks, enabling processing of datasets larger than a
-single GPU's memory. Results are aggregated back on the host.
+same JIT-compiled kernel on each device. Both functions now take the CSV file
+path as their first argument. The `run_multi_gpu_jit_large` variant streams the
+CSV file in chunks, enabling processing of datasets larger than a single GPU's
+memory. Results are aggregated back on the host.
 
 ## Project Structure
 

--- a/src/main.cu
+++ b/src/main.cu
@@ -55,10 +55,11 @@ std::vector<float> run_multi_gpu_jit_host(const HostTable &host,
   return results;
 }
 
-// Convenience wrapper that loads the sample CSV and prints the results.
-void run_multi_gpu_jit(const std::string &expr_cuda,
+// Convenience wrapper that loads a CSV and prints the results.
+void run_multi_gpu_jit(const std::string &csv_path,
+                       const std::string &expr_cuda,
                        const std::string &cond_cuda) {
-  HostTable host = load_csv_to_host("data/test.csv");
+  HostTable host = load_csv_to_host(csv_path);
   auto results = run_multi_gpu_jit_host(host, expr_cuda, cond_cuda);
   for (size_t i = 0; i < results.size(); ++i) {
     std::cout << "MultiGPU Result[" << i << "] = " << results[i] << "\n";
@@ -163,10 +164,13 @@ __global__ void project_revenue_and_adjusted(float *price, int *quantity,
 
 int main(int argc, char **argv) {
   if (argc < 2) {
-    std::cerr << "Usage: ./warpdb \"<expression>\"\n";
+    std::cerr << "Usage: ./warpdb \"<expression>\" [data_file]\n";
     return 1;
   }
   std::string user_query = argv[1];
+  std::string csv_path = "data/test.csv";
+  if (argc >= 3)
+    csv_path = argv[2];
   std::string upper_query = user_query;
   for (auto &c : upper_query)
     c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
@@ -183,7 +187,7 @@ int main(int argc, char **argv) {
   if (!where_part.empty())
     std::cout << "Where: " << where_part << "\n";
 
-  Table table = load_csv_to_gpu("data/test.csv");
+  Table table = load_csv_to_gpu(csv_path);
   std::cout << "Loaded " << table.num_rows << " rows.\n";
   float *d_price = table.get_column_ptr<float>("price");
   int *d_quantity = table.get_column_ptr<int>("quantity");
@@ -399,7 +403,7 @@ int main(int argc, char **argv) {
   // compile
   std::cout << "\n[ JIT Kernel Execution for Expression ]\n";
 
-  jit_compile_and_launch(expr_cuda, condition_cuda,
+  jit_compile_and_launch(cuda_expr, condition_cuda,
 #ifdef USE_ARROW
                          reinterpret_cast<float *>(table.d_price->mutable_data()),
                          reinterpret_cast<int *>(table.d_quantity->mutable_data()),
@@ -425,10 +429,10 @@ int main(int argc, char **argv) {
   schema.release(&schema);
 
   std::cout << "\n[ Multi-GPU JIT Example ]\n";
-  run_multi_gpu_jit(expr_cuda, condition_cuda);
+  run_multi_gpu_jit(csv_path, cuda_expr, condition_cuda);
 
   std::cout << "\n[ Large Multi-GPU Example ]\n";
-  run_multi_gpu_jit_large("data/test.csv", expr_cuda, condition_cuda, 1024);
+  run_multi_gpu_jit_large(csv_path, cuda_expr, condition_cuda, 1024);
 
 
   delete[] h_jit_output;


### PR DESCRIPTION
## Summary
- make `warpdb` accept an optional path to the CSV data file
- propagate the chosen path to multi-GPU examples
- document new argument in README

## Testing
- `cmake -S . -B build -G "Unix Makefiles"` *(fails: nvcc installed but build fails later due to missing headers)*
- `cmake --build build -j $(nproc)` *(fails: unable to compile)*


------
https://chatgpt.com/codex/tasks/task_e_6845ccfd07ac832880260275bfab0ef3