### PR TITLE
Add python module test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,11 +94,19 @@ add_library(warpdb_lib STATIC
     src/jit.cpp
     src/arrow_utils.cpp
 )
-set_target_properties(warpdb_lib PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
+set_target_properties(warpdb_lib PROPERTIES
+    CUDA_SEPARABLE_COMPILATION ON
+    POSITION_INDEPENDENT_CODE ON)
 target_link_libraries(warpdb_lib PUBLIC CUDA::nvrtc CUDA::cuda_driver)
 
 find_package(pybind11 CONFIG QUIET)
 if(pybind11_FOUND)
     pybind11_add_module(pywarpdb bindings/python/pywarpdb.cpp)
     target_link_libraries(pywarpdb PRIVATE warpdb_lib)
+    find_package(Python3 REQUIRED COMPONENTS Interpreter)
+    add_test(NAME python_module_test
+             COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_python.py)
+    set_tests_properties(python_module_test PROPERTIES
+        DEPENDS pywarpdb
+        ENVIRONMENT "PYTHONPATH=$<TARGET_FILE_DIR:pywarpdb>")
 endif()


### PR DESCRIPTION
## Summary
- run WarpDB as a static library with PIC so it can be linked into Python modules
- integrate Python module test with CTest when pybind11 is available
- ensure the Python test depends on the `pywarpdb` module and sets up `PYTHONPATH`

## Testing
- `cmake .. -DCMAKE_CXX_STANDARD=17 -DCMAKE_CUDA_STANDARD=17`
- `cmake --build . --target pywarpdb expression_test expression_tests query_parser_test -j4`
- `ctest -R python_module_test --output-on-failure` *(fails: undefined symbol `_Z19load_parquet_to_gpuRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE`)*

------
https://chatgpt.com/codex/tasks/task_e_6845cd02548c83289cb3f137f407b2a8