### PR TITLE
Make pybind11 optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,16 +116,23 @@ set_target_properties(warpdb_lib PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
 target_link_libraries(warpdb_lib PUBLIC CUDA::cudart CUDA::nvrtc CUDA::cuda_driver)
 
 
-find_package(pybind11 CONFIG QUIET)
-if(pybind11_FOUND)
-    pybind11_add_module(pywarpdb bindings/python/pywarpdb.cpp)
-    target_link_libraries(pywarpdb PRIVATE warpdb_lib)
-    find_package(Python3 REQUIRED COMPONENTS Interpreter)
-    add_test(NAME python_module_test
-             COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_python.py)
-    set_tests_properties(python_module_test PROPERTIES
-        DEPENDS pywarpdb
-        ENVIRONMENT "PYTHONPATH=$<TARGET_FILE_DIR:pywarpdb>")
+option(WARPDB_BUILD_PYTHON "Build Python bindings with pybind11" ON)
+
+if(WARPDB_BUILD_PYTHON)
+    find_package(pybind11 CONFIG QUIET)
+    if(pybind11_FOUND)
+        message(STATUS "Found pybind11 - building Python bindings")
+        pybind11_add_module(pywarpdb bindings/python/pywarpdb.cpp)
+        target_link_libraries(pywarpdb PRIVATE warpdb_lib)
+        find_package(Python3 REQUIRED COMPONENTS Interpreter)
+        add_test(NAME python_module_test
+                 COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_python.py)
+        set_tests_properties(python_module_test PROPERTIES
+            DEPENDS pywarpdb
+            ENVIRONMENT "PYTHONPATH=$<TARGET_FILE_DIR:pywarpdb>")
+    else()
+        message(STATUS "pybind11 not found - Python bindings will not be built")
+    endif()
 endif()
 
 # Test building without Apache Arrow available

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ WarpDB consists of the following main components:
 - C++17 compatible compiler
 - NVIDIA GPU with compute capability 7.0 or higher
 - [Optional] Apache Arrow with CUDA support for zero-copy columnar data
-- [Optional] `pybind11` to build the Python module
+- [Optional] `pybind11` to build the Python module (set `-DWARPDB_BUILD_PYTHON=ON`)
 
 The build system uses `find_package(CUDAToolkit)` to automatically locate
 NVRTC and the CUDA driver. Ensure the CUDA toolkit is installed and available
@@ -74,11 +74,13 @@ mkdir build
 cd build
 cmake ..  # CMake will locate the CUDA toolkit automatically
 # Arrow and pybind11 are discovered via `find_package` when installed
+# Use -DWARPDB_BUILD_PYTHON=OFF to skip the Python bindings
 make
 ```
 
-When `pybind11` is available a `pywarpdb` Python module is generated in the
-build directory alongside the C++ binaries.
+If `pybind11` is detected a `pywarpdb` module is produced in the build
+directory alongside the C++ binaries.  When it is not found the rest of the
+project still builds normally.
 
 ## Testing
 
@@ -117,8 +119,9 @@ You can then invoke the function in a query:
 
 ### Python API
 
-You can also use WarpDB directly from Python if `pybind11` is available.
-The bindings are compiled during the CMake build when `pybind11` is detected:
+You can also use WarpDB directly from Python when the optional bindings are
+enabled.  They are built automatically when `pybind11` is present and
+`-DWARPDB_BUILD_PYTHON=ON` (the default) is passed to CMake:
 
 ```python
 import pywarpdb
@@ -249,7 +252,8 @@ The project has recently gained several improvements:
 - Basic query optimization uses column statistics for simple filter pushdown.
 - RAII wrappers manage CUDA contexts and modules to avoid resource leaks.
 - Helper functions demonstrate streaming across multiple GPUs.
-- Python bindings are available when `pybind11` is installed.
+- Python bindings are built when `pybind11` is installed and
+  `-DWARPDB_BUILD_PYTHON=ON`.
 
 ## Limitations
 
@@ -258,7 +262,8 @@ The project has recently gained several improvements:
 - Basic support for joins, aggregations, ordering, and LIMIT clauses
 - Limited error handling for malformed queries
 - Loading Parquet/Arrow/ORC files requires Apache Arrow
-- Building the Python module requires `pybind11`
+- Building the Python module requires `pybind11` or disable it with
+  `-DWARPDB_BUILD_PYTHON=OFF`
 
 ## Future Improvements
 


### PR DESCRIPTION
## Summary
- allow building without pybind11 by adding `WARPDB_BUILD_PYTHON` option
- show a status message when pybind11 is missing
- document optional Python bindings in the README

## Testing
- `cmake ..` *(fails: failed to find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6845d19172f483289006f9d41b20fd44