### PR TITLE
Move multi GPU helper to shared source

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ set(WARPDB_SRC
     src/expression.cpp
     src/jit.cpp
     src/arrow_utils.cpp
+    src/multi_gpu_utils.cpp
     src/optimizer.cpp
 )
 
@@ -100,6 +101,7 @@ add_library(warpdb_lib STATIC
     src/expression.cpp
     src/jit.cpp
     src/arrow_utils.cpp
+    src/multi_gpu_utils.cpp
 )
 
 set_target_properties(warpdb_lib PROPERTIES

--- a/include/multi_gpu_utils.hpp
+++ b/include/multi_gpu_utils.hpp
@@ -1,0 +1,12 @@
+#pragma once
+#include <string>
+#include <vector>
+#include "csv_loader.hpp"
+#include "jit.hpp"
+
+// Execute a JIT compiled expression across all available GPUs for the provided
+// host table chunk. Falls back to single GPU execution when only one device is
+// present.
+std::vector<float> run_multi_gpu_jit_host(const HostTable &host,
+                                          const std::string &expr_cuda,
+                                          const std::string &cond_cuda);

--- a/src/main.cu
+++ b/src/main.cu
@@ -8,52 +8,7 @@
 #include "arrow_utils.hpp"
 #include "optimizer.hpp"
 #include <fstream>
-// Execute a JIT compiled expression across all available GPUs for the provided
-// host table chunk. Returns the aggregated results.
-std::vector<float> run_multi_gpu_jit_host(const HostTable &host,
-                                          const std::string &expr_cuda,
-                                          const std::string &cond_cuda) {
-  int device_count = 0;
-  cudaGetDeviceCount(&device_count);
-  if (device_count < 2) {
-    std::cout << "Only " << device_count
-              << " GPU detected. Skipping multi-device example.\n";
-    return {};
-  }
-
-  int N = host.num_rows();
-  int chunk = (N + device_count - 1) / device_count;
-  std::vector<float> results(N);
-
-  for (int dev = 0; dev < device_count; ++dev) {
-    int start = dev * chunk;
-    int end = std::min(start + chunk, N);
-    if (start >= end)
-      break;
-    int local_N = end - start;
-
-    HostTable sub;
-    sub.price.assign(host.price.begin() + start, host.price.begin() + end);
-    sub.quantity.assign(host.quantity.begin() + start,
-                        host.quantity.begin() + end);
-    Table dtab = upload_to_gpu(sub);
-
-    float *d_out;
-    cudaMalloc(&d_out, sizeof(float) * local_N);
-
-    jit_compile_and_launch(expr_cuda, cond_cuda, dtab.d_price, dtab.d_quantity,
-                           d_out, local_N, dev);
-
-    cudaMemcpy(results.data() + start, d_out, sizeof(float) * local_N,
-               cudaMemcpyDeviceToHost);
-
-    cudaFree(d_out);
-    cudaFree(dtab.d_price);
-    cudaFree(dtab.d_quantity);
-  }
-
-  return results;
-}
+#include "multi_gpu_utils.hpp"
 
 // Convenience wrapper that loads a CSV and prints the results.
 void run_multi_gpu_jit(const std::string &csv_path,

--- a/src/multi_gpu_utils.cpp
+++ b/src/multi_gpu_utils.cpp
@@ -1,0 +1,58 @@
+#include "multi_gpu_utils.hpp"
+#include <cuda_runtime.h>
+#include <algorithm>
+
+std::vector<float> run_multi_gpu_jit_host(const HostTable &host,
+                                          const std::string &expr_cuda,
+                                          const std::string &cond_cuda) {
+    int device_count = 0;
+    cudaGetDeviceCount(&device_count);
+    if (device_count < 2) {
+        Table dtab = upload_to_gpu(host);
+        float *d_out;
+        cudaMalloc(&d_out, sizeof(float) * host.num_rows());
+        jit_compile_and_launch(expr_cuda, cond_cuda, dtab.d_price,
+                               dtab.d_quantity, d_out, host.num_rows(), 0);
+        std::vector<float> result(host.num_rows());
+        cudaMemcpy(result.data(), d_out, sizeof(float) * host.num_rows(),
+                   cudaMemcpyDeviceToHost);
+        cudaFree(d_out);
+        cudaFree(dtab.d_price);
+        cudaFree(dtab.d_quantity);
+        return result;
+    }
+
+    int N = host.num_rows();
+    int chunk = (N + device_count - 1) / device_count;
+    std::vector<float> results(N);
+
+    for (int dev = 0; dev < device_count; ++dev) {
+        int start = dev * chunk;
+        int end = std::min(start + chunk, N);
+        if (start >= end)
+            break;
+        int local_N = end - start;
+
+        HostTable sub;
+        sub.price.assign(host.price.begin() + start, host.price.begin() + end);
+        sub.quantity.assign(host.quantity.begin() + start,
+                            host.quantity.begin() + end);
+        cudaSetDevice(dev);
+        Table dtab = upload_to_gpu(sub);
+
+        float *d_out;
+        cudaMalloc(&d_out, sizeof(float) * local_N);
+
+        jit_compile_and_launch(expr_cuda, cond_cuda, dtab.d_price,
+                               dtab.d_quantity, d_out, local_N, dev);
+
+        cudaMemcpy(results.data() + start, d_out, sizeof(float) * local_N,
+                   cudaMemcpyDeviceToHost);
+
+        cudaFree(d_out);
+        cudaFree(dtab.d_price);
+        cudaFree(dtab.d_quantity);
+    }
+
+    return results;
+}

--- a/src/warpdb.cpp
+++ b/src/warpdb.cpp
@@ -7,6 +7,7 @@
 #include <map>
 #include <utility>
 #include "arrow_loader.hpp"
+#include "multi_gpu_utils.hpp"
 #include <stdexcept>
 #include <unordered_set>
 #include <memory>
@@ -41,60 +42,6 @@ void validate_ast(const ASTNode *node,
     }
 }
 
-std::vector<float> run_multi_gpu_jit_host(const HostTable &host,
-                                          const std::string &expr_cuda,
-                                          const std::string &cond_cuda) {
-    int device_count = 0;
-    cudaGetDeviceCount(&device_count);
-    if (device_count < 2) {
-        Table dtab = upload_to_gpu(host);
-        float *d_out;
-        cudaMalloc(&d_out, sizeof(float) * host.num_rows());
-        jit_compile_and_launch(expr_cuda, cond_cuda, dtab.d_price,
-                               dtab.d_quantity, d_out, host.num_rows(), 0);
-        std::vector<float> result(host.num_rows());
-        cudaMemcpy(result.data(), d_out, sizeof(float) * host.num_rows(),
-                   cudaMemcpyDeviceToHost);
-        cudaFree(d_out);
-        cudaFree(dtab.d_price);
-        cudaFree(dtab.d_quantity);
-        return result;
-    }
-
-    int N = host.num_rows();
-    int chunk = (N + device_count - 1) / device_count;
-    std::vector<float> results(N);
-
-    for (int dev = 0; dev < device_count; ++dev) {
-        int start = dev * chunk;
-        int end = std::min(start + chunk, N);
-        if (start >= end)
-            break;
-        int local_N = end - start;
-
-        HostTable sub;
-        sub.price.assign(host.price.begin() + start, host.price.begin() + end);
-        sub.quantity.assign(host.quantity.begin() + start,
-                            host.quantity.begin() + end);
-        cudaSetDevice(dev);
-        Table dtab = upload_to_gpu(sub);
-
-        float *d_out;
-        cudaMalloc(&d_out, sizeof(float) * local_N);
-
-        jit_compile_and_launch(expr_cuda, cond_cuda, dtab.d_price,
-                               dtab.d_quantity, d_out, local_N, dev);
-
-        cudaMemcpy(results.data() + start, d_out, sizeof(float) * local_N,
-                   cudaMemcpyDeviceToHost);
-
-        cudaFree(d_out);
-        cudaFree(dtab.d_price);
-        cudaFree(dtab.d_quantity);
-    }
-
-    return results;
-}
 } // namespace
 
 WarpDB::WarpDB(const std::string &filepath) {


### PR DESCRIPTION
## Summary
- factor out `run_multi_gpu_jit_host` into `multi_gpu_utils` library
- use the new helper in both WarpDB and the main application
- wire up CMake to build the new file

## Testing
- `cmake -S . -B build` *(fails: Failed to find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6845d18334ac8328bb76032e5a91bce1