### PR TITLE
Add HAVING and OFFSET support

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,13 +255,13 @@ The project has recently gained several improvements:
 
 - Currently supports a limited subset of SQL functionality
 - Only supports simple CSV files with basic data types
-- Basic support for joins, aggregations, ordering, and LIMIT clauses
+- Basic support for joins, aggregations, ordering, LIMIT and OFFSET clauses, and HAVING filters
 - Limited error handling for malformed queries
 - Loading Parquet/Arrow/ORC files requires Apache Arrow
 - Building the Python module requires `pybind11`
 
 ## Future Improvements
 
-- Continue extending SQL support beyond JOIN/GROUP BY/ORDER BY and LIMIT
+- Continue extending SQL support beyond JOIN/GROUP BY/ORDER BY, LIMIT, HAVING, and OFFSET
 - Better error handling and query validation
 - Additional data source support (e.g. Avro)

--- a/include/expression.hpp
+++ b/include/expression.hpp
@@ -101,6 +101,10 @@ struct LimitClause {
   int count;
 };
 
+struct OffsetClause {
+  int count;
+};
+
 struct WindowFunctionNode : public ASTNode {
   AggregationType agg;
   ASTNodePtr expr;
@@ -127,8 +131,10 @@ struct QueryAST {
   std::optional<JoinClause> join;
   std::optional<ASTNodePtr> where;
   std::optional<GroupByClause> group_by;
+  std::optional<ASTNodePtr> having;
   std::optional<OrderByClause> order_by;
   std::optional<LimitClause> limit;
+  std::optional<OffsetClause> offset;
 };
 
 QueryAST parse_query(const std::vector<Token> &tokens);

--- a/tests/sql_features_test.cpp
+++ b/tests/sql_features_test.cpp
@@ -9,5 +9,11 @@ int main(){
 
     auto limited = db.query_sql("SELECT price FROM test ORDER BY price DESC LIMIT 2");
     assert(limited.size() == 2);
+
+    auto offset = db.query_sql("SELECT price FROM test ORDER BY price DESC OFFSET 1 LIMIT 2");
+    assert(offset.size() == 2);
+
+    auto having = db.query_sql("SELECT SUM(price) FROM test GROUP BY quantity HAVING SUM(price) > 15 ORDER BY quantity ASC");
+    assert(having.size() == 3);
     return 0;
 }


### PR DESCRIPTION
## Summary
- extend token list and parser to handle HAVING and OFFSET
- support new clauses in execution engine
- document HAVING/OFFSET support
- update SQL feature tests

## Testing
- `bash tests/build_no_arrow.sh` *(fails: identifier cuda_expr is undefined)*

------
https://chatgpt.com/codex/tasks/task_e_6845d0609f7883289908713ee63d3986