### PR TITLE
Improve parser error handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,13 @@ add_executable(query_parser_test
 
 add_test(NAME query_parser_test COMMAND query_parser_test)
 
+add_executable(parsing_error_tests
+    tests/parsing_error_tests.cpp
+    src/expression.cpp
+)
+
+add_test(NAME parsing_error_tests COMMAND parsing_error_tests)
+
 
 add_executable(sql_features_test
     tests/sql_features_test.cpp

--- a/src/expression.cpp
+++ b/src/expression.cpp
@@ -3,6 +3,22 @@
 #include <unordered_set>
 #include <stdexcept>
 
+static const char *token_type_name(TokenType t) {
+  switch (t) {
+  case TokenType::Identifier:
+    return "Identifier";
+  case TokenType::Number:
+    return "Number";
+  case TokenType::Operator:
+    return "Operator";
+  case TokenType::Keyword:
+    return "Keyword";
+  case TokenType::End:
+    return "End";
+  }
+  return "Unknown";
+}
+
 std::vector<Token> tokenize(const std::string &input) {
   std::vector<Token> tokens;
   size_t i = 0;
@@ -59,8 +75,9 @@ std::vector<Token> tokenize(const std::string &input) {
       // Remaining single-character operators
       tokens.push_back({TokenType::Operator, std::string(1, input[i++])});
     } else {
-      throw std::runtime_error("Unknown character: " +
-                               std::string(1, input[i]));
+      throw std::runtime_error("Unknown character '" +
+                               std::string(1, input[i]) +
+                               "' at position " + std::to_string(i));
     }
   }
 
@@ -177,7 +194,9 @@ ASTNodePtr parse_factor() {
       throw std::runtime_error("Expected ')'");
     return node;
   } else {
-    throw std::runtime_error("Unexpected token: " + tok.value);
+    throw std::runtime_error(std::string("Unexpected token (") +
+                             token_type_name(tok.type) + ": " + tok.value +
+                             ")");
   }
 }
 } // end anonymous namespace
@@ -215,9 +234,12 @@ ASTNodePtr parse_logical_or(const std::vector<Token> &tokens) {
 }
 
 QueryAST parse_query(const std::vector<Token> &tokens) {
+  size_t end = tokens.size();
+  if (end > 0 && tokens[end - 1].type == TokenType::End)
+    --end;
   size_t pos = 0;
   auto expect_kw = [&](const std::string &kw) {
-    if (pos >= tokens.size() || tokens[pos].type != TokenType::Keyword ||
+    if (pos >= end || tokens[pos].type != TokenType::Keyword ||
         tokens[pos].value != kw)
       throw std::runtime_error("Expected keyword: " + kw);
     pos++;
@@ -259,6 +281,8 @@ QueryAST parse_query(const std::vector<Token> &tokens) {
                                                        parse_expression(inner));
           }
           return std::make_unique<AggregationNode>(at, parse_expression(inner));
+        } else {
+          throw std::runtime_error("Invalid syntax for " + kw + " aggregation");
         }
       }
     }
@@ -267,12 +291,12 @@ QueryAST parse_query(const std::vector<Token> &tokens) {
     return parse_expression(tmp);
   };
 
-  while (pos < tokens.size()) {
+  while (pos < end) {
     if (tokens[pos].type == TokenType::Keyword && tokens[pos].value == "FROM")
       break;
     std::vector<Token> item;
     int depth = 0;
-    while (pos < tokens.size()) {
+    while (pos < end) {
       if (tokens[pos].type == TokenType::Operator && tokens[pos].value == "(")
         depth++;
       if (tokens[pos].type == TokenType::Operator && tokens[pos].value == ")")
@@ -286,26 +310,26 @@ QueryAST parse_query(const std::vector<Token> &tokens) {
       item.push_back(tokens[pos++]);
     }
     query.select_list.push_back(parse_select_item(item));
-    if (pos < tokens.size() && tokens[pos].type == TokenType::Operator &&
+    if (pos < end && tokens[pos].type == TokenType::Operator &&
         tokens[pos].value == ",")
       pos++; // skip comma
   }
 
   expect_kw("FROM");
-  if (pos >= tokens.size() || tokens[pos].type != TokenType::Identifier)
+  if (pos >= end || tokens[pos].type != TokenType::Identifier)
     throw std::runtime_error("Expected table name after FROM");
   query.from_table = tokens[pos++].value;
 
-  if (pos < tokens.size() && tokens[pos].type == TokenType::Keyword &&
+  if (pos < end && tokens[pos].type == TokenType::Keyword &&
       tokens[pos].value == "JOIN") {
     pos++;
-    if (pos >= tokens.size() || tokens[pos].type != TokenType::Identifier)
+    if (pos >= end || tokens[pos].type != TokenType::Identifier)
       throw std::runtime_error("Expected table name after JOIN");
     JoinClause jc;
     jc.table = tokens[pos++].value;
     expect_kw("ON");
     size_t start = pos;
-    while (pos < tokens.size() &&
+    while (pos < end &&
            !(tokens[pos].type == TokenType::Keyword &&
              (tokens[pos].value == "WHERE" || tokens[pos].value == "GROUP" ||
               tokens[pos].value == "ORDER")))
@@ -316,11 +340,11 @@ QueryAST parse_query(const std::vector<Token> &tokens) {
     query.join = std::move(jc);
   }
 
-  if (pos < tokens.size() && tokens[pos].type == TokenType::Keyword &&
+  if (pos < end && tokens[pos].type == TokenType::Keyword &&
       tokens[pos].value == "WHERE") {
     pos++;
     size_t start = pos;
-    while (pos < tokens.size() &&
+    while (pos < end &&
            !(tokens[pos].type == TokenType::Keyword &&
              (tokens[pos].value == "GROUP" || tokens[pos].value == "ORDER")))
       pos++;
@@ -329,14 +353,14 @@ QueryAST parse_query(const std::vector<Token> &tokens) {
     query.where = parse_expression(w);
   }
 
-  if (pos < tokens.size() && tokens[pos].type == TokenType::Keyword &&
+  if (pos < end && tokens[pos].type == TokenType::Keyword &&
       tokens[pos].value == "GROUP") {
     pos++;
     expect_kw("BY");
     GroupByClause gb;
-    while (pos < tokens.size()) {
+    while (pos < end) {
       size_t start = pos;
-      while (pos < tokens.size() &&
+      while (pos < end &&
              !(tokens[pos].type == TokenType::Operator &&
                tokens[pos].value == ",") &&
              !(tokens[pos].type == TokenType::Keyword &&
@@ -345,22 +369,22 @@ QueryAST parse_query(const std::vector<Token> &tokens) {
       std::vector<Token> key(tokens.begin() + start, tokens.begin() + pos);
       key.push_back({TokenType::End, ""});
       gb.keys.push_back(parse_expression(key));
-      if (pos < tokens.size() && tokens[pos].type == TokenType::Operator &&
+      if (pos < end && tokens[pos].type == TokenType::Operator &&
           tokens[pos].value == ",")
         pos++;
-      if (pos < tokens.size() && tokens[pos].type == TokenType::Keyword &&
+      if (pos < end && tokens[pos].type == TokenType::Keyword &&
           tokens[pos].value == "ORDER")
         break;
     }
     query.group_by = std::move(gb);
   }
 
-  if (pos < tokens.size() && tokens[pos].type == TokenType::Keyword &&
+  if (pos < end && tokens[pos].type == TokenType::Keyword &&
       tokens[pos].value == "ORDER") {
     pos++;
     expect_kw("BY");
     size_t start = pos;
-    while (pos < tokens.size() &&
+    while (pos < end &&
            !(tokens[pos].type == TokenType::Keyword &&
              (tokens[pos].value == "ASC" || tokens[pos].value == "DESC")))
       pos++;
@@ -369,7 +393,7 @@ QueryAST parse_query(const std::vector<Token> &tokens) {
     OrderByClause ob;
     ob.expr = parse_expression(ord);
     ob.ascending = true;
-    if (pos < tokens.size() && tokens[pos].type == TokenType::Keyword &&
+    if (pos < end && tokens[pos].type == TokenType::Keyword &&
         (tokens[pos].value == "ASC" || tokens[pos].value == "DESC")) {
       ob.ascending = tokens[pos].value == "ASC";
       pos++;
@@ -377,14 +401,19 @@ QueryAST parse_query(const std::vector<Token> &tokens) {
     query.order_by = std::move(ob);
   }
 
-  if (pos < tokens.size() && tokens[pos].type == TokenType::Keyword &&
+  if (pos < end && tokens[pos].type == TokenType::Keyword &&
       tokens[pos].value == "LIMIT") {
     pos++;
-    if (pos >= tokens.size() || tokens[pos].type != TokenType::Number)
+    if (pos >= end || tokens[pos].type != TokenType::Number)
       throw std::runtime_error("Expected numeric value after LIMIT");
     LimitClause lc{std::stoi(tokens[pos].value)};
     pos++;
     query.limit = lc;
+  }
+
+  if (pos != end) {
+    throw std::runtime_error("Unexpected token in query near: " +
+                             tokens[pos].value);
   }
 
   return query;

--- a/src/warpdb.cpp
+++ b/src/warpdb.cpp
@@ -238,7 +238,12 @@ bool eval_condition(const ASTNode *node, const Row &r) {
 
 std::vector<float> WarpDB::query_sql(const std::string &sql) {
     auto tokens = tokenize(sql);
-    QueryAST ast = parse_query(tokens);
+    QueryAST ast;
+    try {
+        ast = parse_query(tokens);
+    } catch (const std::exception &e) {
+        throw std::runtime_error(std::string("Failed to parse SQL: ") + e.what());
+    }
 
     std::vector<Row> rows;
     rows.reserve(host_table_.num_rows());

--- a/tests/parsing_error_tests.cpp
+++ b/tests/parsing_error_tests.cpp
@@ -1,0 +1,53 @@
+#include "expression.hpp"
+#include <cassert>
+#include <iostream>
+#include <stdexcept>
+
+void test_invalid_character() {
+    bool threw = false;
+    try {
+        auto toks = tokenize("price & 5");
+        (void)toks;
+    } catch (const std::runtime_error &e) {
+        threw = true;
+        std::string msg = e.what();
+        assert(msg.find("Unknown character") != std::string::npos);
+    }
+    assert(threw && "Expected tokenizer failure");
+}
+
+void test_unexpected_token_query() {
+    bool threw = false;
+    try {
+        auto tokens = tokenize("SELECT price FROM test EXTRA");
+        QueryAST q = parse_query(tokens);
+        (void)q;
+    } catch (const std::runtime_error &e) {
+        threw = true;
+        std::string msg = e.what();
+        assert(msg.find("Unexpected token") != std::string::npos);
+    }
+    assert(threw && "Expected parse_query to fail");
+}
+
+void test_unbalanced_parentheses() {
+    bool threw = false;
+    try {
+        auto tokens = tokenize("(price + 5");
+        auto ast = parse_expression(tokens);
+        (void)ast;
+    } catch (const std::runtime_error &e) {
+        threw = true;
+        std::string msg = e.what();
+        assert(msg.find("Expected ')'" ) != std::string::npos);
+    }
+    assert(threw && "Expected expression parse failure");
+}
+
+int main() {
+    test_invalid_character();
+    test_unexpected_token_query();
+    test_unbalanced_parentheses();
+    std::cout << "All regression tests passed\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary
- refine error messages in `tokenize` and parsing routines
- validate aggregation syntax and end of query
- wrap SQL parsing with detailed exception context
- add regression tests for invalid tokens and malformed queries

## Testing
- `g++ -std=c++17 -Iinclude tests/expression_tests.cpp src/expression.cpp -o /tmp/expression_tests && /tmp/expression_tests`
- `g++ -std=c++17 -Iinclude tests/query_parser_test.cpp src/expression.cpp -o /tmp/query_parser_test && /tmp/query_parser_test`
- `g++ -std=c++17 -Iinclude tests/parsing_error_tests.cpp src/expression.cpp -o /tmp/parsing_error_tests && /tmp/parsing_error_tests`
- `g++ -std=c++17 -Iinclude tests/tokenizer_tests.cpp src/expression.cpp -o /tmp/tokenizer_tests && /tmp/tokenizer_tests`


------
https://chatgpt.com/codex/tasks/task_e_6845d19049e4832880c201eb2084f02b