### PR TITLE
Add HAVING and DISTINCT features

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,12 @@ target_link_libraries(sql_features_test PRIVATE warpdb_lib)
 
 add_test(NAME sql_features_test COMMAND sql_features_test)
 
+add_executable(having_distinct_test
+    tests/having_distinct_test.cpp
+)
+target_link_libraries(having_distinct_test PRIVATE warpdb_lib)
+add_test(NAME having_distinct_test COMMAND having_distinct_test)
+
 add_executable(jit_error_test
     tests/jit_error_test.cpp
     src/jit.cpp

--- a/include/expression.hpp
+++ b/include/expression.hpp
@@ -124,11 +124,13 @@ struct GroupByClause {
 struct QueryAST {
   std::vector<ASTNodePtr> select_list;
   std::string from_table;
-  std::optional<JoinClause> join;
+  std::vector<JoinClause> joins;
   std::optional<ASTNodePtr> where;
   std::optional<GroupByClause> group_by;
+  std::optional<ASTNodePtr> having;
   std::optional<OrderByClause> order_by;
   std::optional<LimitClause> limit;
+  bool distinct = false;
 };
 
 QueryAST parse_query(const std::vector<Token> &tokens);

--- a/src/warpdb.cpp
+++ b/src/warpdb.cpp
@@ -273,8 +273,41 @@ std::vector<float> WarpDB::query_sql(const std::string &sql) {
             g.min = std::min(g.min, (double)val);
             g.max = std::max(g.max, (double)val);
         }
+
+        auto eval_group_expr = [&](const ASTNode *node, const AggData &g)->float {
+            if (auto c = dynamic_cast<const ConstantNode*>(node)) {
+                return std::stof(c->value);
+            } else if (auto ag = dynamic_cast<const AggregationNode*>(node)) {
+                switch(ag->agg){
+                case AggregationType::Sum: return g.sum;
+                case AggregationType::Avg: return g.sum / g.count;
+                case AggregationType::Count: return g.count;
+                case AggregationType::Min: return g.min;
+                case AggregationType::Max: return g.max;
+                }
+            } else if (auto b = dynamic_cast<const BinaryOpNode*>(node)) {
+                float l = eval_group_expr(b->left.get(), g);
+                float r = eval_group_expr(b->right.get(), g);
+                const std::string &op = b->op;
+                if(op=="+") return l+r;
+                if(op=="-") return l-r;
+                if(op=="*") return l*r;
+                if(op=="/") return l/r;
+                if(op==">") return l>r;
+                if(op=="<") return l<r;
+                if(op==">=") return l>=r;
+                if(op=="<=") return l<=r;
+                if(op=="==") return l==r;
+                if(op=="!=") return l!=r;
+            }
+            return 0.0f;
+        };
+
         for (const auto &kv : groups) {
             const AggData &g = kv.second;
+            if (ast.having) {
+                if (!eval_group_expr(ast.having.value().get(), g)) continue;
+            }
             switch (agg->agg) {
             case AggregationType::Sum: result.push_back(g.sum); break;
             case AggregationType::Avg: result.push_back(g.sum / g.count); break;
@@ -287,6 +320,13 @@ std::vector<float> WarpDB::query_sql(const std::string &sql) {
         for (const auto &r : rows) {
             result.push_back(eval_node(ast.select_list[0].get(), r));
         }
+    }
+
+    if (ast.distinct) {
+        std::vector<float> tmp = result;
+        std::sort(tmp.begin(), tmp.end());
+        tmp.erase(std::unique(tmp.begin(), tmp.end()), tmp.end());
+        result.swap(tmp);
     }
 
     if (ast.order_by) {

--- a/tests/having_distinct_test.cpp
+++ b/tests/having_distinct_test.cpp
@@ -1,0 +1,15 @@
+#include "warpdb.hpp"
+#include <cassert>
+#include <iostream>
+
+int main(){
+    WarpDB db("data/test.csv");
+    auto res = db.query_sql("SELECT SUM(price) FROM test GROUP BY quantity HAVING COUNT(price) > 1");
+    assert(res.empty());
+
+    auto res2 = db.query_sql("SELECT DISTINCT quantity FROM test ORDER BY quantity DESC");
+    assert(res2.size() == 4);
+    assert(res2.front() > res2.back());
+    std::cout << "HAVING/DISTINCT tests passed\n";
+    return 0;
+}

--- a/tests/query_parser_test.cpp
+++ b/tests/query_parser_test.cpp
@@ -7,7 +7,7 @@ int main() {
     auto tokens = tokenize(q);
     QueryAST ast = parse_query(tokens);
     assert(ast.select_list.size() == 2);
-    assert(ast.join.has_value());
+    assert(!ast.joins.empty());
     assert(ast.where.has_value());
     assert(ast.group_by.has_value());
     assert(ast.order_by.has_value());


### PR DESCRIPTION
## Summary
- expand QueryAST for HAVING and DISTINCT
- support HAVING clause and DISTINCT values when parsing queries
- evaluate HAVING and DISTINCT in `WarpDB::query_sql`
- allow multiple JOIN clauses during parsing
- add a unit test for HAVING and DISTINCT and update existing parser test

## Testing
- `bash tests/build_no_arrow.sh` *(fails: Failed to find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6845d18df3088328adea9a9e45026039