### PR TITLE
Add simplified Parquet/ORC loaders

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,8 @@ find_package(CUDAToolkit REQUIRED)
 
 find_package(Arrow QUIET COMPONENTS cuda)
 
+option(USE_SIMPLE_READERS "Enable simplified Parquet/ORC readers" OFF)
+
 if(Arrow_FOUND)
     message(STATUS "Found Apache Arrow: ${Arrow_VERSION}")
     add_definitions(-DUSE_ARROW)
@@ -31,6 +33,9 @@ set(WARPDB_SRC
 
 if(Arrow_FOUND)
     list(APPEND WARPDB_SRC src/arrow_loader.cpp)
+elseif(USE_SIMPLE_READERS)
+    list(APPEND WARPDB_SRC src/arrow_loader.cpp)
+    add_definitions(-DUSE_SIMPLE_READERS)
 else()
     list(APPEND WARPDB_SRC src/arrow_loader_stub.cpp)
 endif()
@@ -44,6 +49,8 @@ set_target_properties(warpdb PROPERTIES
 
 if(Arrow_FOUND)
     target_link_libraries(warpdb PRIVATE CUDA::cudart CUDA::nvrtc CUDA::cuda_driver ${Arrow_LIBRARIES})
+elseif(USE_SIMPLE_READERS)
+    target_link_libraries(warpdb PRIVATE CUDA::cudart CUDA::nvrtc CUDA::cuda_driver parquet orc)
 else()
     target_link_libraries(warpdb PRIVATE CUDA::cudart CUDA::nvrtc CUDA::cuda_driver)
 endif()
@@ -109,6 +116,10 @@ target_link_libraries(warpdb_lib PUBLIC CUDA::nvrtc CUDA::cuda_driver)
 
 if(Arrow_FOUND)
     target_sources(warpdb_lib PRIVATE src/arrow_loader.cpp)
+elseif(USE_SIMPLE_READERS)
+    target_sources(warpdb_lib PRIVATE src/arrow_loader.cpp)
+    target_link_libraries(warpdb_lib PUBLIC parquet orc)
+    add_definitions(-DUSE_SIMPLE_READERS)
 else()
     target_sources(warpdb_lib PRIVATE src/arrow_loader_stub.cpp)
 endif()

--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ WarpDB implements several CUDA kernels:
 The project has recently gained several improvements:
 
 - Optional Apache Arrow integration can be enabled with `USE_ARROW`.
+- When Arrow is not available, simplified Parquet and ORC readers can be enabled with `USE_SIMPLE_READERS`.
 - Basic query optimization uses column statistics for simple filter pushdown.
 - RAII wrappers manage CUDA contexts and modules to avoid resource leaks.
 - Helper functions demonstrate streaming across multiple GPUs.

--- a/include/arrow_loader.hpp
+++ b/include/arrow_loader.hpp
@@ -3,7 +3,7 @@
 #include <memory>
 #include <string>
 #include <stdexcept>
-#ifdef USE_ARROW
+#if defined(USE_ARROW)
 #include <arrow/api.h>
 #include <arrow/cuda/api.h>
 #endif
@@ -16,8 +16,12 @@ struct ArrowTable {
 #endif
 };
 
-#ifdef USE_ARROW
+#if defined(USE_ARROW)
 ArrowTable load_csv_arrow(const std::string &filepath);
+Table load_parquet_to_gpu(const std::string &filepath);
+Table load_arrow_to_gpu(const std::string &filepath);
+Table load_orc_to_gpu(const std::string &filepath);
+#elif defined(USE_SIMPLE_READERS)
 Table load_parquet_to_gpu(const std::string &filepath);
 Table load_arrow_to_gpu(const std::string &filepath);
 Table load_orc_to_gpu(const std::string &filepath);

--- a/src/arrow_loader.cpp
+++ b/src/arrow_loader.cpp
@@ -1,4 +1,4 @@
-#ifdef USE_ARROW
+#if defined(USE_ARROW)
 #include "arrow_loader.hpp"
 #include <arrow/csv/api.h>
 #include <arrow/io/api.h>
@@ -140,4 +140,101 @@ Table load_orc_to_gpu(const std::string &filepath) {
   return table_from_arrow(table);
 }
 
-#endif // USE_ARROW
+#elif defined(USE_SIMPLE_READERS)
+#include "arrow_loader.hpp"
+#include "csv_loader.hpp"
+#include <parquet/api/reader.h>
+#include <orc/OrcFile.hh>
+#include <cuda_runtime.h>
+
+#define CUDA_CHECK(err) \
+  do { \
+    if (err != cudaSuccess) { \
+      std::cerr << "CUDA Error: " << cudaGetErrorString(err) << "\n"; \
+      exit(1); \
+    } \
+  } while (0)
+
+namespace {
+Table finalize_table(std::vector<float> &price, std::vector<int> &qty) {
+  float *d_price;
+  int *d_quantity;
+  size_t N = price.size();
+  CUDA_CHECK(cudaMalloc(&d_price, sizeof(float) * N));
+  CUDA_CHECK(cudaMalloc(&d_quantity, sizeof(int) * N));
+  CUDA_CHECK(cudaMemcpy(d_price, price.data(), sizeof(float) * N, cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(d_quantity, qty.data(), sizeof(int) * N, cudaMemcpyHostToDevice));
+  Table table;
+  table.d_price = d_price;
+  table.d_quantity = d_quantity;
+  table.num_rows = static_cast<int>(N);
+  table.columns = { {"price", DataType::Float32, d_price, table.num_rows},
+                    {"quantity", DataType::Int32, d_quantity, table.num_rows} };
+  TableStats stats;
+  if(!price.empty()) {
+    auto [min_p, max_p] = std::minmax_element(price.begin(), price.end());
+    stats.price.min = *min_p; stats.price.max = *max_p;
+  }
+  if(!qty.empty()) {
+    auto [min_q, max_q] = std::minmax_element(qty.begin(), qty.end());
+    stats.quantity.min = *min_q; stats.quantity.max = *max_q;
+  }
+  table.stats = stats;
+  return table;
+}
+} // namespace
+
+Table load_parquet_to_gpu(const std::string &filepath) {
+  auto reader = parquet::ParquetFileReader::OpenFile(filepath, false);
+  auto metadata = reader->metadata();
+  int64_t rows = metadata->num_rows();
+  std::vector<float> price(rows);
+  std::vector<int> quantity(rows);
+  int64_t offset = 0;
+  for (int rg = 0; rg < metadata->num_row_groups(); ++rg) {
+    auto group = reader->RowGroup(rg);
+    auto price_col = static_cast<parquet::DoubleReader*>(group->Column(0).get());
+    auto qty_col = static_cast<parquet::Int32Reader*>(group->Column(1).get());
+    while (price_col->HasNext()) {
+      int64_t values_read = 0;
+      double p; int32_t q; int16_t d, r;
+      price_col->ReadBatch(1, &d, &r, &p, &values_read);
+      qty_col->ReadBatch(1, &d, &r, &q, &values_read);
+      price[offset] = static_cast<float>(p);
+      quantity[offset] = q;
+      ++offset;
+    }
+  }
+  reader->Close();
+  return finalize_table(price, quantity);
+}
+
+Table load_arrow_to_gpu(const std::string &filepath) {
+  throw std::runtime_error("Arrow IPC files require USE_ARROW");
+}
+
+Table load_orc_to_gpu(const std::string &filepath) {
+  std::unique_ptr<orc::InputStream> in = orc::readLocalFile(filepath);
+  orc::ReaderOptions opts;
+  auto reader = orc::createReader(std::move(in), opts);
+  uint64_t rows = reader->getNumberOfRows();
+  std::vector<float> price(rows);
+  std::vector<int> quantity(rows);
+  orc::RowReaderOptions row_opts;
+  std::unique_ptr<orc::RowReader> row_reader = reader->createRowReader(row_opts);
+  uint64_t offset = 0;
+  std::unique_ptr<orc::ColumnVectorBatch> batch = row_reader->createRowBatch(1024);
+  while (row_reader->next(*batch)) {
+    auto *struct_batch = dynamic_cast<orc::StructVectorBatch*>(batch.get());
+    auto *price_batch = dynamic_cast<orc::DoubleVectorBatch*>(struct_batch->fields[0]);
+    auto *qty_batch = dynamic_cast<orc::LongVectorBatch*>(struct_batch->fields[1]);
+    for (uint64_t i = 0; i < batch->numElements; ++i) {
+      price[offset] = static_cast<float>(price_batch->data[i]);
+      quantity[offset] = static_cast<int>(qty_batch->data[i]);
+      ++offset;
+    }
+  }
+  return finalize_table(price, quantity);
+}
+
+#endif // USE_SIMPLE_READERS

--- a/src/arrow_loader_stub.cpp
+++ b/src/arrow_loader_stub.cpp
@@ -1,7 +1,7 @@
 #include "arrow_loader.hpp"
 #include <stdexcept>
 
-#ifndef USE_ARROW
+#if !defined(USE_ARROW) && !defined(USE_SIMPLE_READERS)
 Table load_parquet_to_gpu(const std::string &filepath) {
     throw std::runtime_error("Arrow support not enabled");
 }

--- a/src/warpdb.cpp
+++ b/src/warpdb.cpp
@@ -110,7 +110,7 @@ WarpDB::WarpDB(const std::string &filepath) {
 
         host_table_ = load_json_to_host(filepath);
 
-#ifdef USE_ARROW
+#if defined(USE_ARROW) || defined(USE_SIMPLE_READERS)
 
     } else if (ext == "parquet") {
         table_ = load_parquet_to_gpu(filepath);


### PR DESCRIPTION
## Summary
- add optional simplified Parquet/ORC readers
- use arrow_loader.cpp when USE_SIMPLE_READERS is on
- hook simplified readers into WarpDB build
- document USE_SIMPLE_READERS option

## Testing
- `cmake .. -DUSE_SIMPLE_READERS=ON -DCMAKE_DISABLE_FIND_PACKAGE_Arrow=ON` *(fails: Failed to find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6845d190d47c83289ac38a1d009ab16a