### PR TITLE
Fix HAVING parsing with OFFSET

### DIFF
--- a/src/expression.cpp
+++ b/src/expression.cpp
@@ -443,18 +443,6 @@ QueryAST parse_query(const std::vector<Token> &tokens) {
   }
 
 
-  if (pos < tokens.size() && tokens[pos].type == TokenType::Keyword &&
-      tokens[pos].value == "HAVING") {
-    pos++;
-    size_t start = pos;
-    while (pos < tokens.size() &&
-           !(tokens[pos].type == TokenType::Keyword &&
-             (tokens[pos].value == "ORDER" || tokens[pos].value == "LIMIT")))
-      pos++;
-    std::vector<Token> hv(tokens.begin() + start, tokens.begin() + pos);
-    hv.push_back({TokenType::End, ""});
-    query.having = parse_expression(hv);
-  }
 
   if (pos < tokens.size() && tokens[pos].type == TokenType::Keyword &&
 
@@ -469,6 +457,8 @@ QueryAST parse_query(const std::vector<Token> &tokens) {
     std::vector<Token> hv(tokens.begin() + start, tokens.begin() + pos);
     hv.push_back({TokenType::End, ""});
     query.having = parse_expression(hv);
+    if (pos == tokens.size())
+      end = pos;
   }
 
   if (pos < tokens.size() && tokens[pos].type == TokenType::Keyword &&
@@ -520,6 +510,7 @@ QueryAST parse_query(const std::vector<Token> &tokens) {
     OffsetClause oc{std::stoi(tokens[pos].value)};
     pos++;
     query.offset = oc;
+  }
 
   if (pos != end) {
     throw std::runtime_error("Unexpected token in query near: " +

--- a/tests/having_offset_query_test.cpp
+++ b/tests/having_offset_query_test.cpp
@@ -1,0 +1,23 @@
+#include "expression.hpp"
+#include <cassert>
+#include <iostream>
+
+int main() {
+    {
+        std::string q = "SELECT price FROM test GROUP BY price HAVING price > 5";
+        auto tokens = tokenize(q);
+        QueryAST ast = parse_query(tokens);
+        assert(ast.having.has_value());
+        assert(!ast.offset.has_value());
+    }
+    {
+        std::string q = "SELECT price FROM test GROUP BY price HAVING price > 5 OFFSET 2";
+        auto tokens = tokenize(q);
+        QueryAST ast = parse_query(tokens);
+        assert(ast.having.has_value());
+        assert(ast.offset.has_value());
+        assert(ast.offset->count == 2);
+    }
+    std::cout << "HAVING OFFSET parse tests passed\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary
- remove old HAVING handler
- fix end position after parsing HAVING
- close OFFSET block
- add test covering HAVING with/without OFFSET

## Testing
- `g++ -std=c++17 -Iinclude tests/having_offset_query_test.cpp src/expression.cpp -o ho_test`
- `./ho_test`
- `g++ -std=c++17 -Iinclude tests/query_parser_test.cpp src/expression.cpp -o qp_test`
- `./qp_test`
- `cmake ..` *(fails: Failed to find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_685969f130988328b4f8a52f278f5000