### PR TITLE
Add optional shm_name for Arrow export

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ WarpDB is a GPU-accelerated SQL query engine that demonstrates how to leverage C
 - **Arrow Columnar Format**: Optionally load data using Apache Arrow for zero-copy
   interoperability with Pandas, PyTorch, and Spark
 - **Arrow Results**: Retrieve query results as Arrow buffers for easy sharing
+  (optionally using a custom shared memory name)
 - **User-Provided CUDA Functions**: Extend queries with functions defined in `custom.cu`
 - **Column Statistics & Optimizer**: Collect min/max/null counts for basic filter pushdown and kernel fusion
 - **Multi-GPU Execution**: Robust support for running queries across multiple GPUs, including streaming large CSV files
@@ -145,8 +146,9 @@ db = pywarpdb.WarpDB("data/test.csv")  # or data/test.json
 result = db.query("price * quantity WHERE price > 10")
 print(result)
 
-# Export result as an Arrow array
-arr_capsule, schema_capsule = db.query_arrow("price * quantity")
+# Export result as an Arrow array stored in shared memory
+arr_capsule, schema_capsule = db.query_arrow(
+    "price * quantity", shared_memory=True, shm_name="/my_result")
 import pyarrow as pa
 arrow_arr = pa.Array._import_from_c(arr_capsule, schema_capsule)
 ```

--- a/bindings/python/pywarpdb.cpp
+++ b/bindings/python/pywarpdb.cpp
@@ -16,21 +16,24 @@ PYBIND11_MODULE(pywarpdb, m) {
                     py::arg("rows_per_chunk") = 1000000,
                     R"pbdoc(Stream a CSV file in chunks across all GPUs and return results.)pbdoc")
         .def("query_arrow",
-             [](WarpDB &db, const std::string &expr, bool shared_memory) {
-                 auto arr = new ArrowArray();
-                 auto schema = new ArrowSchema();
-                 db.query_arrow(expr, arr, schema, shared_memory);
-                 py::capsule array_capsule(arr, [](void *ptr) {
-                     ArrowArray *arr = reinterpret_cast<ArrowArray *>(ptr);
-                     if (arr->release) arr->release(arr);
-                 });
-                 py::capsule schema_capsule(schema, [](void *ptr) {
-                     ArrowSchema *schema = reinterpret_cast<ArrowSchema *>(ptr);
-                     if (schema->release) schema->release(schema);
-                 });
-                 return py::make_tuple(array_capsule, schema_capsule);
-             },
+             [](WarpDB &db, const std::string &expr, bool shared_memory,
+                const std::string &shm_name) {
+                auto arr = new ArrowArray();
+                auto schema = new ArrowSchema();
+                 db.query_arrow(expr, arr, schema, shared_memory,
+                                shm_name.c_str());
+                py::capsule array_capsule(arr, [](void *ptr) {
+                    ArrowArray *arr = reinterpret_cast<ArrowArray *>(ptr);
+                    if (arr->release) arr->release(arr);
+                });
+                py::capsule schema_capsule(schema, [](void *ptr) {
+                    ArrowSchema *schema = reinterpret_cast<ArrowSchema *>(ptr);
+                    if (schema->release) schema->release(schema);
+                });
+                return py::make_tuple(array_capsule, schema_capsule);
+            },
              py::arg("expr"), py::arg("shared_memory") = false,
+             py::arg("shm_name") = "/warpdb_result",
              R"pbdoc(Return result as Arrow C Data Interface capsules.
 
 The returned tuple contains (ArrowArray capsule, ArrowSchema capsule).

--- a/include/arrow_utils.hpp
+++ b/include/arrow_utils.hpp
@@ -6,6 +6,9 @@
 
 // Simple utility to export a float array to Arrow buffers.
 // If use_shared_memory is true, the data buffer will be mapped using
-// POSIX shared memory so external processes can read it.
+// POSIX shared memory so external processes can read it.  When
+// shared memory is used, `shm_name` specifies the name of the
+// POSIX shared memory region.  It defaults to "/warpdb_result".
 void export_to_arrow(const float* data, int64_t length, bool use_shared_memory,
-                     ArrowArray* out_array, ArrowSchema* out_schema);
+                     ArrowArray* out_array, ArrowSchema* out_schema,
+                     const char* shm_name = "/warpdb_result");

--- a/include/warpdb.hpp
+++ b/include/warpdb.hpp
@@ -37,9 +37,11 @@ public:
     // Execute a query and export the results as Arrow buffers.
     // The ArrowArray and ArrowSchema must be provided by the caller.
     // When use_shared_memory is true, the result buffer is created in
-    // POSIX shared memory so other processes can access it.
+    // POSIX shared memory so other processes can access it.  The name of
+    // the shared memory region can be customized with `shm_name`.
     void query_arrow(const std::string &expr, ArrowArray *out_array,
-                     ArrowSchema *out_schema, bool use_shared_memory = false);
+                     ArrowSchema *out_schema, bool use_shared_memory = false,
+                     const char* shm_name = "/warpdb_result");
 
 
 private:

--- a/src/arrow_utils.cpp
+++ b/src/arrow_utils.cpp
@@ -35,14 +35,15 @@ static void release_arrow_schema(struct ArrowSchema* schema) {
 }
 
 void export_to_arrow(const float* data, int64_t length, bool use_shared_memory,
-                     ArrowArray* out_array, ArrowSchema* out_schema) {
+                     ArrowArray* out_array, ArrowSchema* out_schema,
+                     const char* shm_name) {
     if (!out_array || !out_schema) throw std::invalid_argument("Null output");
     ArrowBufferInfo* info = new ArrowBufferInfo();
     info->size = sizeof(float) * length;
     info->shared = use_shared_memory;
 
     if (use_shared_memory) {
-        info->name = "/warpdb_result";
+        info->name = shm_name ? shm_name : "/warpdb_result";
         info->fd = shm_open(info->name.c_str(), O_CREAT | O_RDWR, 0600);
         if (info->fd < 0) {
             delete info;

--- a/src/warpdb.cpp
+++ b/src/warpdb.cpp
@@ -498,10 +498,11 @@ std::vector<float> WarpDB::query_sql(const std::string &sql) {
 }
 
 void WarpDB::query_arrow(const std::string &expr, ArrowArray *out_array,
-                         ArrowSchema *out_schema, bool use_shared_memory) {
+                         ArrowSchema *out_schema, bool use_shared_memory,
+                         const char* shm_name) {
     auto result = query(expr);
     export_to_arrow(result.data(), static_cast<int64_t>(result.size()),
-                    use_shared_memory, out_array, out_schema);
+                    use_shared_memory, out_array, out_schema, shm_name);
 
 }
 


### PR DESCRIPTION
## Summary
- allow customizing the shared memory segment name when exporting Arrow data
- plumb shm_name through `WarpDB::query_arrow` and Python bindings
- document the new argument in README

## Testing
- `cmake -S . -B build` *(passes)*
- `cmake --build build -j $(nproc)` *(fails: compiler errors)*

------
https://chatgpt.com/codex/tasks/task_e_685969ef8e0483289478418fe9f2001e