### PR TITLE
test: verify Python query results

### DIFF
--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1,5 +1,13 @@
+import csv
 import pywarpdb
 
 db = pywarpdb.WarpDB("data/test.csv")
 result = db.query("price + 1")
-print("rows", len(result))
+
+with open("data/test.csv", newline="") as f:
+    reader = csv.DictReader(f)
+    expected = [float(row["price"]) + 1 for row in reader]
+
+assert len(result) == len(expected)
+assert result == expected
+


### PR DESCRIPTION
## Summary
- expand Python module test to validate result count and values from `data/test.csv`

## Testing
- `python tests/test_python.py` *(fails: No module named 'pywarpdb')*

------
https://chatgpt.com/codex/tasks/task_e_688bff04ce188328bc521242fbe5728e