### PR TITLE
Optimize constant filters using table stats

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,14 @@ add_executable(jit_arch_test
 target_link_libraries(jit_arch_test PRIVATE CUDA::cudart CUDA::nvrtc CUDA::cuda_driver)
 add_test(NAME jit_arch_test COMMAND jit_arch_test)
 
+add_executable(optimizer_test
+    tests/optimizer_test.cpp
+    src/expression.cpp
+    src/optimizer.cpp
+)
+target_link_libraries(optimizer_test PRIVATE CUDA::cudart CUDA::nvrtc CUDA::cuda_driver)
+add_test(NAME optimizer_test COMMAND optimizer_test)
+
 add_library(warpdb_lib STATIC
     src/warpdb.cpp
     src/csv_loader.cpp

--- a/include/optimizer.hpp
+++ b/include/optimizer.hpp
@@ -6,3 +6,10 @@
 
 void execute_query_optimized(const std::string &expr_part,
                              const std::string &where_part, Table &table);
+
+// Analyze a filter condition to determine if it is always true or always
+// false based on table statistics. The AST is assumed to represent a boolean
+// expression. If the expression can be evaluated statically, either
+// `always_true` or `always_false` will be set to true.
+void analyze_condition(const ASTNode *node, const TableStats &stats,
+                       bool &always_true, bool &always_false);

--- a/src/optimizer.cpp
+++ b/src/optimizer.cpp
@@ -10,13 +10,116 @@ float parse_constant(const std::string &val) {
     return std::stof(val);
 }
 
-void analyze_condition(const ASTNode *, const TableStats &,
+} // namespace
+
+void analyze_condition(const ASTNode *node, const TableStats &stats,
                        bool &always_true, bool &always_false) {
     always_true = false;
     always_false = false;
-}
+    if (!node)
+        return;
 
-} // namespace
+    if (auto bin = dynamic_cast<const BinaryOpNode *>(node)) {
+        // Handle logical operators by recursively analyzing children
+        if (bin->op == "&&" || bin->op == "||") {
+            bool l_true = false, l_false = false;
+            bool r_true = false, r_false = false;
+            analyze_condition(bin->left.get(), stats, l_true, l_false);
+            analyze_condition(bin->right.get(), stats, r_true, r_false);
+
+            if (bin->op == "&&") {
+                if (l_false || r_false)
+                    always_false = true;
+                if (l_true && r_true)
+                    always_true = true;
+            } else { // ||
+                if (l_true || r_true)
+                    always_true = true;
+                if (l_false && r_false)
+                    always_false = true;
+            }
+            return;
+        }
+
+        // Check for comparisons between a column and a constant
+        const VariableNode *var = nullptr;
+        const ConstantNode *cnst = nullptr;
+        bool var_left = true;
+
+        if (bin->left->type() == ASTNodeType::Variable &&
+            bin->right->type() == ASTNodeType::Constant) {
+            var = static_cast<const VariableNode *>(bin->left.get());
+            cnst = static_cast<const ConstantNode *>(bin->right.get());
+        } else if (bin->left->type() == ASTNodeType::Constant &&
+                   bin->right->type() == ASTNodeType::Variable) {
+            var = static_cast<const VariableNode *>(bin->right.get());
+            cnst = static_cast<const ConstantNode *>(bin->left.get());
+            var_left = false;
+        }
+
+        if (var && cnst) {
+            float c = parse_constant(cnst->value);
+            float min = 0.0f, max = 0.0f;
+            bool known = true;
+
+            if (var->name == "price") {
+                min = stats.price.min;
+                max = stats.price.max;
+            } else if (var->name == "quantity") {
+                min = static_cast<float>(stats.quantity.min);
+                max = static_cast<float>(stats.quantity.max);
+            } else {
+                known = false;
+            }
+
+            if (known) {
+                std::string op = bin->op;
+                if (!var_left) {
+                    if (op == ">")
+                        op = "<";
+                    else if (op == "<")
+                        op = ">";
+                    else if (op == ">=")
+                        op = "<=";
+                    else if (op == "<=")
+                        op = ">=";
+                }
+
+                if (op == ">") {
+                    if (min > c)
+                        always_true = true;
+                    else if (max <= c)
+                        always_false = true;
+                } else if (op == ">=") {
+                    if (min >= c)
+                        always_true = true;
+                    else if (max < c)
+                        always_false = true;
+                } else if (op == "<") {
+                    if (max < c)
+                        always_true = true;
+                    else if (min >= c)
+                        always_false = true;
+                } else if (op == "<=") {
+                    if (max <= c)
+                        always_true = true;
+                    else if (min > c)
+                        always_false = true;
+                } else if (op == "==" || op == "=") {
+                    if (min == max && min == c)
+                        always_true = true;
+                    else if (c < min || c > max)
+                        always_false = true;
+                } else if (op == "!=") {
+                    if (min == max && min == c)
+                        always_false = true;
+                    else if (c < min || c > max)
+                        always_true = true;
+                }
+            }
+        }
+    }
+}
 
 void execute_query_optimized(const std::string &expr_part,
                              const std::string &where_part, Table &table) {

--- a/tests/optimizer_test.cpp
+++ b/tests/optimizer_test.cpp
@@ -1,0 +1,36 @@
+#include "optimizer.hpp"
+#include <cassert>
+#include <sstream>
+#include <iostream>
+
+static void test_always_false_via_execute() {
+    Table table;
+    table.num_rows = 5;
+    // Capture output to verify the optimizer triggers early return
+    std::ostringstream oss;
+    std::streambuf *old_buf = std::cout.rdbuf(oss.rdbuf());
+    execute_query_optimized("price", "price > 0", table);
+    std::cout.rdbuf(old_buf);
+    std::string out = oss.str();
+    assert(out.find("[Optimizer] Filter eliminates all rows.") != std::string::npos);
+}
+
+static void test_analyze_condition_always_false() {
+    auto tokens = tokenize("price > 100");
+    auto ast = parse_expression(tokens);
+    TableStats stats;
+    stats.price.min = 10.0f;
+    stats.price.max = 50.0f;
+    bool always_true = false;
+    bool always_false = false;
+    analyze_condition(ast.get(), stats, always_true, always_false);
+    assert(!always_true);
+    assert(always_false);
+}
+
+int main() {
+    test_always_false_via_execute();
+    test_analyze_condition_always_false();
+    std::cout << "Optimizer tests passed\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary
- implement `analyze_condition` to reason about comparisons against `TableStats`
- expose `analyze_condition` in the optimizer API and test constant-folding
- add CMake target and tests for optimizer condition analysis

## Testing
- `cmake -S . -B build` *(fails: Failed to find nvcc)*
- `apt-get install -y nvidia-cuda-toolkit` *(fails: ca-certificates-java post-installation script returned error)*

------
https://chatgpt.com/codex/tasks/task_e_688bff07dc54832893556eb5efa75cff