### PR TITLE
Fix limit-offset order and extend tests

### DIFF
--- a/src/warpdb.cpp
+++ b/src/warpdb.cpp
@@ -418,19 +418,16 @@ std::vector<float> WarpDB::query_sql(const std::string &sql) {
         result.resize(table_.num_rows);
         cudaMemcpy(result.data(), d_out, sizeof(float)*table_.num_rows, cudaMemcpyDeviceToHost);
         cudaFree(d_out);
+    }
 
-        if (ast.limit && static_cast<size_t>(ast.limit->count) < result.size())
+    if (ast.limit && static_cast<size_t>(ast.limit->count) < result.size()) {
+        result.resize(ast.limit->count);
+    }
 
     if (ast.offset) {
         size_t off = static_cast<size_t>(ast.offset->count);
         if (off >= result.size()) result.clear();
         else result.erase(result.begin(), result.begin() + off);
-    }
-
-    if (ast.limit) {
-        if (static_cast<size_t>(ast.limit->count) < result.size())
-
-            result.resize(ast.limit->count);
     }
 
     return result;

--- a/tests/sql_features_test.cpp
+++ b/tests/sql_features_test.cpp
@@ -34,8 +34,9 @@ int main(){
     assert(std::abs(limited[1]-prices[1])<1e-5);
 
 
-    auto offset = db.query_sql("SELECT price FROM test ORDER BY price DESC OFFSET 1 LIMIT 2");
-    assert(offset.size() == 2);
+    auto offset = db.query_sql("SELECT price FROM test ORDER BY price DESC LIMIT 2 OFFSET 1");
+    assert(offset.size() == 1);
+    assert(std::abs(offset[0] - prices[1]) < 1e-5);
 
     auto having = db.query_sql("SELECT SUM(price) FROM test GROUP BY quantity HAVING SUM(price) > 15 ORDER BY quantity ASC");
     assert(having.size() == 3);


### PR DESCRIPTION
## Summary
- Apply LIMIT before OFFSET in query result processing
- Expand SQL feature tests to check ORDER BY with LIMIT/OFFSET

## Testing
- `./tests/build_no_arrow.sh` *(fails: Failed to find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_688bff0b2cd483289c0428f86d9611d4