### PR TITLE
Throw exceptions on CUDA errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,11 @@ add_executable(extended_types_test
 target_link_libraries(extended_types_test PRIVATE warpdb_lib)
 add_test(NAME extended_types_test COMMAND extended_types_test)
 
+add_executable(cuda_error_handling_test
+    tests/cuda_error_handling_test.cpp)
+target_link_libraries(cuda_error_handling_test PRIVATE warpdb_lib)
+add_test(NAME cuda_error_handling_test COMMAND cuda_error_handling_test)
+
 
 add_executable(jit_error_test
     tests/jit_error_test.cpp

--- a/src/arrow_loader.cpp
+++ b/src/arrow_loader.cpp
@@ -14,12 +14,12 @@
 #include <arrow/adapters/orc/adapter.h>
 #include <cuda_runtime.h>
 
-#define CUDA_CHECK(err) \
-  do { \
-    if (err != cudaSuccess) { \
-      std::cerr << "CUDA Error: " << cudaGetErrorString(err) << "\n"; \
-      exit(1); \
-    } \
+#define CUDA_CHECK(err)                                                       \
+  do {                                                                       \
+    if ((err) != cudaSuccess) {                                              \
+      throw std::runtime_error(std::string("CUDA Error: ") +                 \
+                               cudaGetErrorString(err));                     \
+    }                                                                        \
   } while (0)
 
 ArrowTable load_csv_arrow(const std::string &filepath) {

--- a/src/csv_loader.cpp
+++ b/src/csv_loader.cpp
@@ -18,12 +18,12 @@
 #include <arrow/cuda/api.h>
 #endif
 
-#define CUDA_CHECK(err) \
-  do { \
-    if (err != cudaSuccess) { \
-      std::cerr << "CUDA Error: " << cudaGetErrorString(err) << "\n"; \
-      exit(1); \
-    } \
+#define CUDA_CHECK(err)                                                       \
+  do {                                                                       \
+    if ((err) != cudaSuccess) {                                              \
+      throw std::runtime_error(std::string("CUDA Error: ") +                 \
+                               cudaGetErrorString(err));                     \
+    }                                                                        \
   } while (0)
 
 namespace {

--- a/src/json_loader.cpp
+++ b/src/json_loader.cpp
@@ -5,12 +5,12 @@
 #include <sstream>
 #include <stdexcept>
 
-#define CUDA_CHECK(err) \
-  do { \
-    if (err != cudaSuccess) { \
-      std::cerr << "CUDA Error: " << cudaGetErrorString(err) << "\n"; \
-      exit(1); \
-    } \
+#define CUDA_CHECK(err)                                                       \
+  do {                                                                       \
+    if ((err) != cudaSuccess) {                                              \
+      throw std::runtime_error(std::string("CUDA Error: ") +                 \
+                               cudaGetErrorString(err));                     \
+    }                                                                        \
   } while (0)
 
 HostTable load_json_to_host(const std::string &filepath) {

--- a/src/main.cu
+++ b/src/main.cu
@@ -118,17 +118,18 @@ __global__ void project_revenue_and_adjusted(float *price, int *quantity,
 }
 
 int main(int argc, char **argv) {
-  if (argc < 2) {
-    std::cerr << "Usage: ./warpdb \"<expression>\" [data_file]\n";
-    return 1;
-  }
-  std::string user_query = argv[1];
-  std::string csv_path = "data/test.csv";
-  if (argc >= 3)
-    csv_path = argv[2];
-  std::string upper_query = user_query;
-  for (auto &c : upper_query)
-    c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
+  try {
+    if (argc < 2) {
+      std::cerr << "Usage: ./warpdb \"<expression>\" [data_file]\n";
+      return 1;
+    }
+    std::string user_query = argv[1];
+    std::string csv_path = "data/test.csv";
+    if (argc >= 3)
+      csv_path = argv[2];
+    std::string upper_query = user_query;
+    for (auto &c : upper_query)
+      c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
 
   std::string expr_part = user_query;
   std::string where_part;
@@ -381,5 +382,9 @@ int main(int argc, char **argv) {
     cudaFree(col.device_ptr);
   }
 
-  return 0;
+    return 0;
+  } catch (const std::exception &e) {
+    std::cerr << "Error: " << e.what() << "\n";
+    return 1;
+  }
 }

--- a/tests/cuda_error_handling_test.cpp
+++ b/tests/cuda_error_handling_test.cpp
@@ -1,0 +1,31 @@
+#include "csv_loader.hpp"
+#include "json_loader.hpp"
+#include <cassert>
+#include <cstdlib>
+#include <iostream>
+
+int main() {
+    // Hide any available GPUs so CUDA calls fail deterministically.
+    setenv("CUDA_VISIBLE_DEVICES", "", 1);
+
+    bool csv_threw = false;
+    try {
+        load_csv_to_gpu("data/test.csv");
+    } catch (const std::runtime_error &e) {
+        csv_threw = true;
+        std::cout << "Caught CSV error: " << e.what() << "\n";
+    }
+    assert(csv_threw && "Expected load_csv_to_gpu to throw");
+
+    bool json_threw = false;
+    try {
+        load_json_to_gpu("data/test.json");
+    } catch (const std::runtime_error &e) {
+        json_threw = true;
+        std::cout << "Caught JSON error: " << e.what() << "\n";
+    }
+    assert(json_threw && "Expected load_json_to_gpu to throw");
+
+    std::cout << "CUDA error handling test passed\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Replace CUDA_CHECK exit calls with std::runtime_error in CSV, JSON and Arrow loaders.
- Wrap main program in try/catch to gracefully handle loader exceptions.
- Add regression test verifying loaders throw when CUDA errors occur.

## Testing
- `cmake ..` *(passed)*
- `cmake --build .` *(failed: /workspace/WarpDB/src/jit.cpp:162:19: error: no matching function for call to ‘push_back(void* const*)’)*

------
https://chatgpt.com/codex/tasks/task_e_688bff08efe4832890a12067eefbb19c