### PR TITLE
Improve CSV chunk termination handling

### DIFF
--- a/src/csv_loader.cpp
+++ b/src/csv_loader.cpp
@@ -218,6 +218,9 @@ HostTable load_csv_chunk(std::istream &stream, int max_rows, bool &finished) {
     }
     ++count;
   }
-  finished = !stream.good();
+  if (stream.fail() && !stream.eof()) {
+    throw std::runtime_error("Error reading CSV: partial line or I/O error");
+  }
+  finished = stream.peek() == EOF;
   return table;
 }

--- a/src/main.cu
+++ b/src/main.cu
@@ -39,8 +39,6 @@ void run_multi_gpu_jit_large(const std::string &csv_path,
   std::vector<float> all_results;
   while (!finished) {
     HostTable chunk = load_csv_chunk(file, rows_per_chunk, finished);
-    if (chunk.num_rows() == 0)
-      break;
     auto part = run_multi_gpu_jit_host(chunk, expr_cuda, cond_cuda);
     all_results.insert(all_results.end(), part.begin(), part.end());
   }

--- a/src/warpdb.cpp
+++ b/src/warpdb.cpp
@@ -518,7 +518,6 @@ std::vector<float> WarpDB::query_multi_gpu_csv(const std::string &csv_path,
     std::vector<float> all_results;
     while (!finished) {
         HostTable chunk = load_csv_chunk(file, rows_per_chunk, finished);
-        if (chunk.num_rows() == 0) break;
         auto part = run_multi_gpu_jit_host(chunk, expr_cuda, condition_cuda);
         all_results.insert(all_results.end(), part.begin(), part.end());
     }

--- a/tests/csv_loader_chunk_test.cpp
+++ b/tests/csv_loader_chunk_test.cpp
@@ -1,0 +1,27 @@
+#include "csv_loader.hpp"
+#include <cassert>
+#include <sstream>
+#include <iostream>
+
+int main() {
+    std::string data =
+        "price,quantity\n"
+        "10.5,3\n"
+        "20.0,4\n"
+        "price,quantity\n"
+        "15.25,2\n"
+        "30.0,5\n";
+    std::istringstream ss(data);
+
+    bool finished = false;
+    HostTable first = load_csv_chunk(ss, 2, finished);
+    assert(first.num_rows() == 2);
+    assert(!finished);
+
+    HostTable second = load_csv_chunk(ss, 2, finished);
+    assert(second.num_rows() == 2);
+    assert(finished);
+
+    std::cout << "CSV chunk test passed\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary
- ensure `load_csv_chunk` explicitly detects EOF and reports I/O errors
- rely on `finished` flag instead of empty chunks in callers
- add regression test for chunked CSV loading when file length is a multiple of `max_rows`

## Testing
- `g++ -std=c++17 tests/csv_loader_chunk_test.cpp src/csv_loader.cpp -Iinclude -I. -o tests/csv_loader_chunk_test`
- `./tests/csv_loader_chunk_test`


------
https://chatgpt.com/codex/tasks/task_e_6893aa5af8108328b41b1e5fd275b957