### PR TITLE
Refactor CUDA error handling into shared header

### DIFF
--- a/include/cuda_utils.hpp
+++ b/include/cuda_utils.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <cuda_runtime.h>
+#include <stdexcept>
+#include <string>
+
+#define CUDA_CHECK(err) \
+  do { \
+    if ((err) != cudaSuccess) { \
+      throw std::runtime_error(std::string("CUDA Error: ") + cudaGetErrorString(err)); \
+    } \
+  } while (0)
+

--- a/src/arrow_loader.cpp
+++ b/src/arrow_loader.cpp
@@ -12,15 +12,8 @@
 #include <arrow/ipc/api.h>
 #include <parquet/arrow/reader.h>
 #include <arrow/adapters/orc/adapter.h>
-#include <cuda_runtime.h>
 
-#define CUDA_CHECK(err)                                                       \
-  do {                                                                       \
-    if ((err) != cudaSuccess) {                                              \
-      throw std::runtime_error(std::string("CUDA Error: ") +                 \
-                               cudaGetErrorString(err));                     \
-    }                                                                        \
-  } while (0)
+#include "cuda_utils.hpp"
 
 ArrowTable load_csv_arrow(const std::string &filepath) {
     auto input_res = arrow::io::ReadableFile::Open(filepath);

--- a/src/csv_loader.cpp
+++ b/src/csv_loader.cpp
@@ -2,12 +2,13 @@
 #ifdef USE_ARROW
 #include "arrow_loader.hpp"
 #endif
-#include <cuda_runtime.h>
 #include <fstream>
 #include <iostream>
 #include <sstream>
 #include <stdexcept>
 #include <algorithm>
+
+#include "cuda_utils.hpp"
 
 #ifdef USE_ARROW
 #include <arrow/api.h>
@@ -17,14 +18,6 @@
 #include <arrow/util/logging.h>
 #include <arrow/cuda/api.h>
 #endif
-
-#define CUDA_CHECK(err)                                                       \
-  do {                                                                       \
-    if ((err) != cudaSuccess) {                                              \
-      throw std::runtime_error(std::string("CUDA Error: ") +                 \
-                               cudaGetErrorString(err));                     \
-    }                                                                        \
-  } while (0)
 
 namespace {
 

--- a/src/json_loader.cpp
+++ b/src/json_loader.cpp
@@ -1,17 +1,10 @@
 #include "json_loader.hpp"
-#include <cuda_runtime.h>
 #include <fstream>
 #include <iostream>
 #include <sstream>
 #include <stdexcept>
 
-#define CUDA_CHECK(err)                                                       \
-  do {                                                                       \
-    if ((err) != cudaSuccess) {                                              \
-      throw std::runtime_error(std::string("CUDA Error: ") +                 \
-                               cudaGetErrorString(err));                     \
-    }                                                                        \
-  } while (0)
+#include "cuda_utils.hpp"
 
 HostTable load_json_to_host(const std::string &filepath) {
   std::ifstream file(filepath);


### PR DESCRIPTION
## Summary
- Introduce `cuda_utils.hpp` with a reusable `CUDA_CHECK` macro
- Replace local macro definitions in CSV, JSON, and Arrow loaders with the shared header

## Testing
- `cmake ..` *(fails: Failed to find nvcc)*
- `sudo apt-get install -y nvidia-cuda-toolkit` *(fails: ca-certificates-java post-installation error)*

------
https://chatgpt.com/codex/tasks/task_e_6893aa5f3e6c83289f402d45e8d9d2f9