### PR TITLE
Handle malformed numeric CSV fields

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,11 @@ add_executable(cuda_error_handling_test
 target_link_libraries(cuda_error_handling_test PRIVATE warpdb_lib)
 add_test(NAME cuda_error_handling_test COMMAND cuda_error_handling_test)
 
+add_executable(csv_loader_error_test
+    tests/csv_loader_error_test.cpp)
+target_link_libraries(csv_loader_error_test PRIVATE warpdb_lib)
+add_test(NAME csv_loader_error_test COMMAND csv_loader_error_test)
+
 
 add_executable(jit_error_test
     tests/jit_error_test.cpp

--- a/data/malformed.csv
+++ b/data/malformed.csv
@@ -1,0 +1,4 @@
+price,quantity
+1.5,10
+abc,20
+2.5,xyz

--- a/include/csv_loader.hpp
+++ b/include/csv_loader.hpp
@@ -12,6 +12,11 @@
 
 enum class DataType { Int32, Int64, Float32, Float64, String };
 
+// Policy for handling conversion errors when parsing CSV values.
+// Strict mode throws on any malformed numeric field, while Permissive mode
+// logs the error and substitutes a default value.
+enum class ParsePolicy { Strict, Permissive };
+
 struct ColumnDesc {
   std::string name;
   DataType type;
@@ -51,7 +56,8 @@ struct Table {
 };
 
 Table load_csv_to_gpu(const std::string &filepath,
-                      const std::vector<DataType> &schema = {});
+                      const std::vector<DataType> &schema = {},
+                      ParsePolicy policy = ParsePolicy::Strict);
 
 using ColumnData = std::variant<std::vector<int32_t>, std::vector<int64_t>,
                                 std::vector<float>, std::vector<double>,
@@ -78,10 +84,12 @@ struct HostTable {
 };
 
 HostTable load_csv_to_host(const std::string &filepath,
-                           const std::vector<DataType> &schema = {});
+                           const std::vector<DataType> &schema = {},
+                           ParsePolicy policy = ParsePolicy::Strict);
 Table upload_to_gpu(const HostTable &table);
 
 // Load at most `max_rows` CSV rows from an open input stream. `finished`
 // will be set to true when no more rows are available.
-HostTable load_csv_chunk(std::istream &stream, int max_rows, bool &finished);
+HostTable load_csv_chunk(std::istream &stream, int max_rows, bool &finished,
+                         ParsePolicy policy = ParsePolicy::Strict);
 

--- a/src/csv_loader.cpp
+++ b/src/csv_loader.cpp
@@ -47,7 +47,8 @@ size_t dtype_size(DataType t) {
 } // namespace
 
 HostTable load_csv_to_host(const std::string &filepath,
-                           const std::vector<DataType> &schema) {
+                           const std::vector<DataType> &schema,
+                           ParsePolicy policy) {
   std::ifstream file(filepath);
   if (!file.is_open()) {
     std::cerr << "Failed to open file: " << filepath << std::endl;
@@ -92,9 +93,11 @@ HostTable load_csv_to_host(const std::string &filepath,
   }
 
   std::string line;
+  int row = 0;
   while (std::getline(file, line)) {
     if (line.empty())
       continue;
+    ++row;
     std::stringstream ss(line);
     std::string value;
     for (size_t i = 0; i < names.size(); ++i) {
@@ -102,16 +105,60 @@ HostTable load_csv_to_host(const std::string &filepath,
       HostColumn &col = host.columns[i];
       switch (col.type) {
       case DataType::Int32:
-        std::get<std::vector<int32_t>>(col.data).push_back(std::stoi(value));
+        try {
+          std::get<std::vector<int32_t>>(col.data).push_back(std::stoi(value));
+        } catch (const std::exception &e) {
+          std::cerr << "Failed to parse int32 value '" << value
+                    << "' at row " << row << " column '" << col.name
+                    << "': " << e.what() << std::endl;
+          if (policy == ParsePolicy::Permissive) {
+            std::get<std::vector<int32_t>>(col.data).push_back(0);
+          } else {
+            throw;
+          }
+        }
         break;
       case DataType::Int64:
-        std::get<std::vector<int64_t>>(col.data).push_back(std::stoll(value));
+        try {
+          std::get<std::vector<int64_t>>(col.data).push_back(std::stoll(value));
+        } catch (const std::exception &e) {
+          std::cerr << "Failed to parse int64 value '" << value
+                    << "' at row " << row << " column '" << col.name
+                    << "': " << e.what() << std::endl;
+          if (policy == ParsePolicy::Permissive) {
+            std::get<std::vector<int64_t>>(col.data).push_back(0);
+          } else {
+            throw;
+          }
+        }
         break;
       case DataType::Float32:
-        std::get<std::vector<float>>(col.data).push_back(std::stof(value));
+        try {
+          std::get<std::vector<float>>(col.data).push_back(std::stof(value));
+        } catch (const std::exception &e) {
+          std::cerr << "Failed to parse float value '" << value
+                    << "' at row " << row << " column '" << col.name
+                    << "': " << e.what() << std::endl;
+          if (policy == ParsePolicy::Permissive) {
+            std::get<std::vector<float>>(col.data).push_back(0.0f);
+          } else {
+            throw;
+          }
+        }
         break;
       case DataType::Float64:
-        std::get<std::vector<double>>(col.data).push_back(std::stod(value));
+        try {
+          std::get<std::vector<double>>(col.data).push_back(std::stod(value));
+        } catch (const std::exception &e) {
+          std::cerr << "Failed to parse double value '" << value
+                    << "' at row " << row << " column '" << col.name
+                    << "': " << e.what() << std::endl;
+          if (policy == ParsePolicy::Permissive) {
+            std::get<std::vector<double>>(col.data).push_back(0.0);
+          } else {
+            throw;
+          }
+        }
         break;
       case DataType::String:
         std::get<std::vector<std::string>>(col.data).push_back(value);
@@ -161,7 +208,8 @@ Table upload_to_gpu(const HostTable &host) {
 }
 
 Table load_csv_to_gpu(const std::string &filepath,
-                      const std::vector<DataType> &schema) {
+                      const std::vector<DataType> &schema,
+                      ParsePolicy policy) {
 #ifdef USE_ARROW
   if (schema.empty()) {
     ArrowTable atable = load_csv_arrow(filepath);
@@ -175,15 +223,16 @@ Table load_csv_to_gpu(const std::string &filepath,
     return table;
   }
 #endif
-  HostTable host = load_csv_to_host(filepath, schema);
+  HostTable host = load_csv_to_host(filepath, schema, policy);
   return upload_to_gpu(host);
 }
 
 Table load_csv_to_gpu(const std::string &filepath) {
-  return load_csv_to_gpu(filepath, {});
+  return load_csv_to_gpu(filepath, {}, ParsePolicy::Strict);
 }
 
-HostTable load_csv_chunk(std::istream &stream, int max_rows, bool &finished) {
+HostTable load_csv_chunk(std::istream &stream, int max_rows, bool &finished,
+                         ParsePolicy policy) {
   std::string header;
   std::streampos pos = stream.tellg();
   if (!(stream >> header)) {
@@ -214,7 +263,19 @@ HostTable load_csv_chunk(std::istream &stream, int max_rows, bool &finished) {
     std::string val;
     for (size_t i = 0; i < names.size(); ++i) {
       if (!std::getline(ss, val, ',')) val.clear();
-      std::get<std::vector<float>>(table.columns[i].data).push_back(std::stof(val));
+      try {
+        std::get<std::vector<float>>(table.columns[i].data).push_back(std::stof(val));
+      } catch (const std::exception &e) {
+        std::cerr << "Failed to parse float value '" << val
+                  << "' at row " << (count + 1) << " column '"
+                  << table.columns[i].name << "': " << e.what()
+                  << std::endl;
+        if (policy == ParsePolicy::Permissive) {
+          std::get<std::vector<float>>(table.columns[i].data).push_back(0.0f);
+        } else {
+          throw;
+        }
+      }
     }
     ++count;
   }

--- a/tests/csv_loader_error_test.cpp
+++ b/tests/csv_loader_error_test.cpp
@@ -1,0 +1,29 @@
+#include "csv_loader.hpp"
+#include <cassert>
+#include <iostream>
+
+int main() {
+    std::vector<DataType> schema = {DataType::Float32, DataType::Int32};
+
+    bool threw = false;
+    try {
+        load_csv_to_host("data/malformed.csv", schema);
+    } catch (const std::exception &) {
+        threw = true;
+    }
+    assert(threw && "Expected load_csv_to_host to throw on malformed data");
+
+    HostTable table = load_csv_to_host("data/malformed.csv", schema, ParsePolicy::Permissive);
+    const auto &price = std::get<std::vector<float>>(table.columns[0].data);
+    const auto &quantity = std::get<std::vector<int32_t>>(table.columns[1].data);
+    assert(price.size() == 3 && quantity.size() == 3);
+    assert(price[0] == 1.5f);
+    assert(price[1] == 0.0f);
+    assert(price[2] == 2.5f);
+    assert(quantity[0] == 10);
+    assert(quantity[1] == 20);
+    assert(quantity[2] == 0);
+
+    std::cout << "csv loader error test passed\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add ParsePolicy enum and optional policy parameter to CSV loading routines
- guard numeric conversions with try/catch and substitute defaults when permissive
- add malformed CSV test and sample data

## Testing
- `cmake --build build` *(fails: no matching function for call to 'push_back(void* const*)' in src/jit.cpp)*
- `g++ -std=c++17 tests/csv_loader_error_test.cpp src/csv_loader.cpp -Iinclude -lcudart -o csv_loader_error_test`
- `./csv_loader_error_test`


------
https://chatgpt.com/codex/tasks/task_e_6893aa5b53ec8328b671636a17489739