### PR TITLE
Check CUDA kernel launches

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,20 @@ WarpDB implements several CUDA kernels:
 - `project_revenue`: Calculates revenue (price × quantity)
 - `project_revenue_and_adjusted`: Calculates multiple expressions in one pass
 
+### Kernel Launch Error Handling
+
+All CUDA kernel launches should be immediately followed by an error check to
+surface misconfigurations early. The expected pattern is:
+
+```cpp
+my_kernel<<<grid, block>>>(args...);
+CUDA_CHECK(cudaGetLastError());
+CUDA_CHECK(cudaDeviceSynchronize()); // retain for debugging when needed
+```
+
+`cudaDeviceSynchronize` calls help catch runtime errors during development and
+should remain where explicitly added for debugging.
+
 ## Development Progress
 
 The project has recently gained several improvements:

--- a/src/main.cu
+++ b/src/main.cu
@@ -192,20 +192,24 @@ int main(int argc, char **argv) {
 
 
   print_first_few<<<1, 4>>>(d_price, d_quantity, table.num_rows);
+  CUDA_CHECK(cudaGetLastError());
   CUDA_CHECK(cudaDeviceSynchronize());
 
   filter_price_gt<<<blocks, threads>>>(d_price, d_quantity,
                                        d_price_filtered.get(),
                                        d_quantity_filtered.get(), d_count.get(),
                                        table.num_rows, threshold);
+  CUDA_CHECK(cudaGetLastError());
 
   print_first_few<<<1, 4>>>(d_price, d_quantity, table.num_rows);
+  CUDA_CHECK(cudaGetLastError());
   CUDA_CHECK(cudaDeviceSynchronize());
 
   filter_price_gt<<<blocks, threads>>>(d_price, d_quantity,
                                        d_price_filtered.get(),
                                        d_quantity_filtered.get(), d_count.get(),
                                        table.num_rows, threshold);
+  CUDA_CHECK(cudaGetLastError());
 
   CUDA_CHECK(cudaDeviceSynchronize());
 
@@ -231,6 +235,7 @@ int main(int argc, char **argv) {
   project_columns<<<blocks, threads>>>(d_price, d_quantity,
       d_selected_price.get(), d_selected_quantity.get(), d_select_count.get(),
       table.num_rows, select_price, select_quantity);
+  CUDA_CHECK(cudaGetLastError());
 
   CUDA_CHECK(cudaDeviceSynchronize());
 
@@ -258,6 +263,7 @@ int main(int argc, char **argv) {
 
   project_revenue<<<blocks, threads>>>(d_price, d_quantity,
       d_revenue.get(), d_revenue_count.get(), table.num_rows, threshold);
+  CUDA_CHECK(cudaGetLastError());
 
   CUDA_CHECK(cudaDeviceSynchronize());
 
@@ -279,6 +285,7 @@ int main(int argc, char **argv) {
       d_price, d_quantity,
       d_revenue_multi.get(), d_adjusted_price.get(), d_multi_count.get(),
       table.num_rows, threshold);
+  CUDA_CHECK(cudaGetLastError());
 
   CUDA_CHECK(cudaDeviceSynchronize());
 


### PR DESCRIPTION
## Summary
- add CUDA error checking after each kernel launch in `src/main.cu`
- document standard kernel launch error-handling pattern in README

## Testing
- `cmake ..` *(fails: Failed to find nvcc)*
- `apt-get install -y nvidia-cuda-toolkit` *(fails: dpkg: error processing package ca-certificates-java)*

------
https://chatgpt.com/codex/tasks/task_e_689d22d797088328980759e8a9490b9e