### PR TITLE
Use nlohmann::json for JSON parsing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ set(CMAKE_CXX_STANDARD 17)
 find_package(CUDAToolkit REQUIRED)
 
 find_package(Arrow QUIET COMPONENTS cuda)
+find_package(nlohmann_json 3.2.0 REQUIRED)
 
 if(Arrow_FOUND)
     message(STATUS "Found Apache Arrow: ${Arrow_VERSION}")
@@ -46,9 +47,9 @@ set_target_properties(warpdb PROPERTIES
 
 
 if(Arrow_FOUND)
-    target_link_libraries(warpdb PRIVATE CUDA::cudart CUDA::nvrtc CUDA::cuda_driver ${Arrow_LIBRARIES})
+    target_link_libraries(warpdb PRIVATE CUDA::cudart CUDA::nvrtc CUDA::cuda_driver ${Arrow_LIBRARIES} nlohmann_json::nlohmann_json)
 else()
-    target_link_libraries(warpdb PRIVATE CUDA::cudart CUDA::nvrtc CUDA::cuda_driver)
+    target_link_libraries(warpdb PRIVATE CUDA::cudart CUDA::nvrtc CUDA::cuda_driver nlohmann_json::nlohmann_json)
 endif()
 
 add_executable(expression_test
@@ -105,6 +106,11 @@ add_executable(csv_loader_error_test
 target_link_libraries(csv_loader_error_test PRIVATE warpdb_lib)
 add_test(NAME csv_loader_error_test COMMAND csv_loader_error_test)
 
+add_executable(json_loader_error_test
+    tests/json_loader_error_test.cpp)
+target_link_libraries(json_loader_error_test PRIVATE warpdb_lib)
+add_test(NAME json_loader_error_test COMMAND json_loader_error_test)
+
 
 add_executable(jit_error_test
     tests/jit_error_test.cpp
@@ -147,7 +153,7 @@ if(Arrow_FOUND)
     target_sources(warpdb_lib PRIVATE src/arrow_loader.cpp)
 endif()
 set_target_properties(warpdb_lib PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
-target_link_libraries(warpdb_lib PUBLIC CUDA::cudart CUDA::nvrtc CUDA::cuda_driver)
+target_link_libraries(warpdb_lib PUBLIC CUDA::cudart CUDA::nvrtc CUDA::cuda_driver nlohmann_json::nlohmann_json)
 
 
 option(WARPDB_BUILD_PYTHON "Build Python bindings with pybind11" ON)

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ WarpDB consists of the following main components:
 - CUDA Toolkit 10.0 or higher
 - CMake 3.18 or higher
 - C++17 compatible compiler
+- [nlohmann/json](https://github.com/nlohmann/json) for JSON parsing
 - NVIDIA GPU with compute capability 7.0 or higher
 - [Optional] Apache Arrow with CUDA support for zero-copy columnar data
 - [Optional] `pybind11` to build the Python module (set `-DWARPDB_BUILD_PYTHON=ON`)

--- a/data/malformed.json
+++ b/data/malformed.json
@@ -1,0 +1,3 @@
+{"price": 1.5, "quantity": 10}
+{"price": 2.0, "quantity": }
+{"price": 2.5, "quantity": 30}

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 from pybind11.setup_helpers import Pybind11Extension, build_ext
 
 include_files = glob('include/*.hpp') + glob('include/*.h')
-data_files = ['data/test.csv', 'data/test.json']
+data_files = ['data/test.csv', 'data/test.json', 'data/malformed.json']
 
 ext_modules = [
     Pybind11Extension(

--- a/src/json_loader.cpp
+++ b/src/json_loader.cpp
@@ -1,8 +1,9 @@
 #include "json_loader.hpp"
 #include <fstream>
 #include <iostream>
-#include <sstream>
 #include <stdexcept>
+
+#include <nlohmann/json.hpp>
 
 #include "cuda_utils.hpp"
 
@@ -14,28 +15,27 @@ HostTable load_json_to_host(const std::string &filepath) {
   }
 
   HostTable host;
-  host.columns = {
-      {"price", DataType::Float32, std::vector<float>()},
-      {"quantity", DataType::Int32, std::vector<int32_t>()}};
+  host.columns = {{"price", DataType::Float32, std::vector<float>()},
+                  {"quantity", DataType::Int32, std::vector<int32_t>()}};
 
   std::string line;
+  size_t line_num = 0;
   while (std::getline(file, line)) {
-    float price = 0.0f;
-    int quantity = 0;
-    size_t p = line.find("\"price\"");
-    size_t q = line.find("\"quantity\"");
-    if (p == std::string::npos || q == std::string::npos)
-      continue;
-    p = line.find(':', p);
-    q = line.find(':', q);
-    if (p == std::string::npos || q == std::string::npos)
-      continue;
-    std::stringstream ss1(line.substr(p + 1));
-    ss1 >> price;
-    std::stringstream ss2(line.substr(q + 1));
-    ss2 >> quantity;
-    std::get<std::vector<float>>(host.columns[0].data).push_back(price);
-    std::get<std::vector<int32_t>>(host.columns[1].data).push_back(quantity);
+    ++line_num;
+    try {
+      auto j = nlohmann::json::parse(line);
+      if (!j.contains("price") || !j.contains("quantity")) {
+        throw std::runtime_error("Missing required fields");
+      }
+      float price = j.at("price").get<float>();
+      int quantity = j.at("quantity").get<int>();
+      std::get<std::vector<float>>(host.columns[0].data).push_back(price);
+      std::get<std::vector<int32_t>>(host.columns[1].data).push_back(quantity);
+    } catch (const std::exception &e) {
+      std::cerr << "Error parsing JSON line " << line_num << ": " << e.what()
+                << std::endl;
+      throw std::runtime_error("Failed to parse JSON line");
+    }
   }
   return host;
 }

--- a/tests/json_loader_error_test.cpp
+++ b/tests/json_loader_error_test.cpp
@@ -1,0 +1,16 @@
+#include "json_loader.hpp"
+#include <cassert>
+#include <iostream>
+
+int main() {
+  bool threw = false;
+  try {
+    load_json_to_host("data/malformed.json");
+  } catch (const std::runtime_error &) {
+    threw = true;
+    std::cout << "Caught JSON parse error\n";
+  }
+  assert(threw && "Expected load_json_to_host to throw on malformed data");
+  std::cout << "json loader error test passed\n";
+  return 0;
+}


### PR DESCRIPTION
## Summary
- Add nlohmann::json as a required dependency and link it for all builds
- Parse JSON input with nlohmann::json and surface line parse errors
- Add malformed JSON fixture and test for loader error handling

## Testing
- `cmake ..` *(fails: Failed to find nvcc)*
- `apt-get install -y nvidia-cuda-toolkit` *(fails: ca-certificates-java post-installation error)*

------
https://chatgpt.com/codex/tasks/task_e_689d274c04388328924778a7cd26e3fe