### PR TITLE
Use RAII for device buffers

### DIFF
--- a/include/csv_loader.hpp
+++ b/include/csv_loader.hpp
@@ -9,6 +9,7 @@
 
 
 #include <variant>
+#include "cuda_utils.hpp"
 
 enum class DataType { Int32, Int64, Float32, Float64, String };
 
@@ -20,7 +21,7 @@ enum class ParsePolicy { Strict, Permissive };
 struct ColumnDesc {
   std::string name;
   DataType type;
-  void *device_ptr;
+  ColumnDevicePtr device_ptr;
   int length;
 };
 
@@ -49,7 +50,7 @@ struct Table {
   T *get_column_ptr(const std::string &name) const {
     for (const auto &col : columns) {
       if (col.name == name)
-        return static_cast<T *>(col.device_ptr);
+        return static_cast<T *>(col.device_ptr.get());
     }
     return nullptr;
   }

--- a/include/cuda_utils.hpp
+++ b/include/cuda_utils.hpp
@@ -25,7 +25,7 @@ public:
     }
   }
   ~DeviceBuffer() {
-    if (ptr_) cudaFree(ptr_);
+    if (ptr_) CUDA_CHECK(cudaFree(ptr_));
   }
   DeviceBuffer(const DeviceBuffer&) = delete;
   DeviceBuffer& operator=(const DeviceBuffer&) = delete;
@@ -34,7 +34,7 @@ public:
   }
   DeviceBuffer& operator=(DeviceBuffer&& other) noexcept {
     if (this != &other) {
-      if (ptr_) cudaFree(ptr_);
+      if (ptr_) CUDA_CHECK(cudaFree(ptr_));
       ptr_ = other.ptr_;
       other.ptr_ = nullptr;
     }
@@ -43,4 +43,35 @@ public:
   T* get() const { return ptr_; }
 private:
   T* ptr_;
+};
+
+// RAII wrapper for untyped device pointers used by Table columns.
+class ColumnDevicePtr {
+public:
+  ColumnDevicePtr() : ptr_(nullptr) {}
+  explicit ColumnDevicePtr(void* ptr) : ptr_(ptr) {}
+  ~ColumnDevicePtr() {
+    if (ptr_) CUDA_CHECK(cudaFree(ptr_));
+  }
+  ColumnDevicePtr(const ColumnDevicePtr&) = delete;
+  ColumnDevicePtr& operator=(const ColumnDevicePtr&) = delete;
+  ColumnDevicePtr(ColumnDevicePtr&& other) noexcept : ptr_(other.ptr_) {
+    other.ptr_ = nullptr;
+  }
+  ColumnDevicePtr& operator=(ColumnDevicePtr&& other) noexcept {
+    if (this != &other) {
+      reset();
+      ptr_ = other.ptr_;
+      other.ptr_ = nullptr;
+    }
+    return *this;
+  }
+  void* get() const { return ptr_; }
+  void reset(void* p = nullptr) {
+    if (ptr_) CUDA_CHECK(cudaFree(ptr_));
+    ptr_ = p;
+  }
+
+private:
+  void* ptr_;
 };

--- a/src/csv_loader.cpp
+++ b/src/csv_loader.cpp
@@ -169,32 +169,37 @@ Table upload_to_gpu(const HostTable &host) {
 
   for (const auto &hcol : host.columns) {
     int N = host.num_rows();
-    void *d_ptr = nullptr;
-    CUDA_CHECK(cudaMalloc(&d_ptr, dtype_size(hcol.type) * N));
+    ColumnDesc col;
+    col.name = hcol.name;
+    col.type = hcol.type;
+    col.length = N;
 
-    if (hcol.type == DataType::Int32) {
-      const auto &vec = std::get<std::vector<int32_t>>(hcol.data);
-      CUDA_CHECK(cudaMemcpy(d_ptr, vec.data(), sizeof(int32_t) * N,
-                            cudaMemcpyHostToDevice));
-    } else if (hcol.type == DataType::Int64) {
-      const auto &vec = std::get<std::vector<int64_t>>(hcol.data);
-      CUDA_CHECK(cudaMemcpy(d_ptr, vec.data(), sizeof(int64_t) * N,
-                            cudaMemcpyHostToDevice));
-    } else if (hcol.type == DataType::Float32) {
-      const auto &vec = std::get<std::vector<float>>(hcol.data);
-      CUDA_CHECK(cudaMemcpy(d_ptr, vec.data(), sizeof(float) * N,
-                            cudaMemcpyHostToDevice));
-    } else if (hcol.type == DataType::Float64) {
-      const auto &vec = std::get<std::vector<double>>(hcol.data);
-      CUDA_CHECK(cudaMemcpy(d_ptr, vec.data(), sizeof(double) * N,
-                            cudaMemcpyHostToDevice));
-    } else if (hcol.type == DataType::String) {
-      // string columns not supported on GPU yet
-      CUDA_CHECK(cudaFree(d_ptr));
-      d_ptr = nullptr;
+    if (hcol.type != DataType::String) {
+      void *d_ptr = nullptr;
+      CUDA_CHECK(cudaMalloc(&d_ptr, dtype_size(hcol.type) * N));
+      col.device_ptr.reset(d_ptr);
+
+      if (hcol.type == DataType::Int32) {
+        const auto &vec = std::get<std::vector<int32_t>>(hcol.data);
+        CUDA_CHECK(cudaMemcpy(col.device_ptr.get(), vec.data(),
+                              sizeof(int32_t) * N, cudaMemcpyHostToDevice));
+      } else if (hcol.type == DataType::Int64) {
+        const auto &vec = std::get<std::vector<int64_t>>(hcol.data);
+        CUDA_CHECK(cudaMemcpy(col.device_ptr.get(), vec.data(),
+                              sizeof(int64_t) * N, cudaMemcpyHostToDevice));
+      } else if (hcol.type == DataType::Float32) {
+        const auto &vec = std::get<std::vector<float>>(hcol.data);
+        CUDA_CHECK(cudaMemcpy(col.device_ptr.get(), vec.data(),
+                              sizeof(float) * N, cudaMemcpyHostToDevice));
+      } else if (hcol.type == DataType::Float64) {
+        const auto &vec = std::get<std::vector<double>>(hcol.data);
+        CUDA_CHECK(cudaMemcpy(col.device_ptr.get(), vec.data(),
+                              sizeof(double) * N, cudaMemcpyHostToDevice));
+      }
+      // string columns are left with nullptr device_ptr
     }
 
-    table.columns.push_back({hcol.name, hcol.type, d_ptr, N});
+    table.columns.push_back(std::move(col));
   }
 
   return table;

--- a/src/jit.cpp
+++ b/src/jit.cpp
@@ -157,10 +157,14 @@ void jit_compile_and_launch(const std::string &expr_code,
   CU_CHECK(cuModuleGetFunction(&kernel_func, module.mod, "user_kernel"));
 
   // Launch
-  std::vector<void *> args;
+  std::vector<void *> column_ptrs;
+  column_ptrs.reserve(table.columns.size());
   for (const auto &c : table.columns) {
-    args.push_back(&c.device_ptr);
+    column_ptrs.push_back(c.device_ptr.get());
   }
+  std::vector<void *> args;
+  args.reserve(column_ptrs.size() + 2);
+  for (auto &p : column_ptrs) args.push_back(&p);
   args.push_back(&d_output);
   args.push_back(&N);
 

--- a/src/main.cu
+++ b/src/main.cu
@@ -152,7 +152,7 @@ int main(int argc, char **argv) {
   struct TableDeleter {
     void operator()(Table *t) const {
       if (!t) return;
-      for (auto &col : t->columns) cudaFree(col.device_ptr);
+      for (auto &col : t->columns) col.device_ptr.reset();
     }
   };
   std::unique_ptr<Table, TableDeleter> table_guard(&table);

--- a/src/multi_gpu_utils.cpp
+++ b/src/multi_gpu_utils.cpp
@@ -12,15 +12,12 @@ std::vector<float> run_multi_gpu_jit_host(const HostTable &host,
     CUDA_CHECK(cudaGetDeviceCount(&device_count));
     if (device_count < 2) {
         Table dtab = upload_to_gpu(host);
-        float *d_out;
-        CUDA_CHECK(cudaMalloc(&d_out, sizeof(float) * host.num_rows()));
-        jit_compile_and_launch(expr_cuda, cond_cuda, dtab, d_out, 0);
+        DeviceBuffer<float> d_out(host.num_rows());
+        jit_compile_and_launch(expr_cuda, cond_cuda, dtab, d_out.get(), 0);
         std::vector<float> result(host.num_rows());
-        CUDA_CHECK(cudaMemcpy(result.data(), d_out, sizeof(float) * host.num_rows(),
+        CUDA_CHECK(cudaMemcpy(result.data(), d_out.get(),
+                              sizeof(float) * host.num_rows(),
                               cudaMemcpyDeviceToHost));
-        CUDA_CHECK(cudaFree(d_out));
-        for (auto &c : dtab.columns)
-            CUDA_CHECK(cudaFree(c.device_ptr));
         return result;
     }
 
@@ -51,18 +48,13 @@ std::vector<float> run_multi_gpu_jit_host(const HostTable &host,
         CUDA_CHECK(cudaSetDevice(dev));
         Table dtab = upload_to_gpu(sub);
 
-        float *d_out;
-        CUDA_CHECK(cudaMalloc(&d_out, sizeof(float) * local_N));
+        DeviceBuffer<float> d_out(local_N);
 
-        jit_compile_and_launch(expr_cuda, cond_cuda, dtab, d_out, dev);
+        jit_compile_and_launch(expr_cuda, cond_cuda, dtab, d_out.get(), dev);
 
-        CUDA_CHECK(cudaMemcpy(results.data() + start, d_out,
+        CUDA_CHECK(cudaMemcpy(results.data() + start, d_out.get(),
                               sizeof(float) * local_N,
                               cudaMemcpyDeviceToHost));
-
-        CUDA_CHECK(cudaFree(d_out));
-        for (auto &c : dtab.columns)
-            CUDA_CHECK(cudaFree(c.device_ptr));
     }
 
     return results;

--- a/src/optimizer.cpp
+++ b/src/optimizer.cpp
@@ -1,6 +1,7 @@
 #include "optimizer.hpp"
 #include "jit.hpp"
 #include <cuda_runtime.h>
+#include "cuda_utils.hpp"
 #include <iostream>
 #include <memory>
 
@@ -149,16 +150,15 @@ void execute_query_optimized(const std::string &expr_part,
         cond_cuda = cond_ast->to_cuda_expr();
     }
 
-    float *d_output;
-    cudaMalloc(&d_output, sizeof(float) * table.num_rows);
-    jit_compile_and_launch(expr_cuda, cond_cuda, table, d_output);
+    DeviceBuffer<float> d_output(table.num_rows);
+    jit_compile_and_launch(expr_cuda, cond_cuda, table, d_output.get());
 
     float *h_out = new float[table.num_rows];
-    cudaMemcpy(h_out, d_output, sizeof(float) * table.num_rows,
-               cudaMemcpyDeviceToHost);
+    CUDA_CHECK(cudaMemcpy(h_out, d_output.get(),
+                          sizeof(float) * table.num_rows,
+                          cudaMemcpyDeviceToHost));
     for (int i = 0; i < table.num_rows; ++i) {
         std::cout << "Result[" << i << "] = " << h_out[i] << "\n";
     }
     delete[] h_out;
-    cudaFree(d_output);
 }

--- a/src/warpdb.cpp
+++ b/src/warpdb.cpp
@@ -1,5 +1,6 @@
 #include "warpdb.hpp"
 #include <cuda_runtime.h>
+#include "cuda_utils.hpp"
 #include <algorithm>
 #include <cctype>
 #include <iostream>
@@ -131,8 +132,7 @@ WarpDB::WarpDB(const std::string &filepath, const std::vector<DataType> &schema)
 
 WarpDB::~WarpDB() {
     for (auto &c : table_.columns) {
-        if (c.device_ptr)
-            cudaFree(c.device_ptr);
+        c.device_ptr.reset();
     }
 }
 
@@ -180,19 +180,14 @@ std::vector<float> WarpDB::query(const std::string &expr) {
         }
     }
 
-    float *d_output;
-    cudaMalloc(&d_output, sizeof(float) * table_.num_rows);
+    DeviceBuffer<float> d_output(table_.num_rows);
 
-    try {
-        jit_compile_and_launch(expr_cuda, condition_cuda, table_, d_output);
-    } catch (const std::exception &e) {
-        cudaFree(d_output);
-        throw;
-    }
+    jit_compile_and_launch(expr_cuda, condition_cuda, table_, d_output.get());
 
     std::vector<float> result(table_.num_rows);
-    cudaMemcpy(result.data(), d_output, sizeof(float) * table_.num_rows, cudaMemcpyDeviceToHost);
-    cudaFree(d_output);
+    CUDA_CHECK(cudaMemcpy(result.data(), d_output.get(),
+                         sizeof(float) * table_.num_rows,
+                         cudaMemcpyDeviceToHost));
     return result;
 }
 

--- a/tests/jit_arch_test.cpp
+++ b/tests/jit_arch_test.cpp
@@ -30,8 +30,6 @@ int main() {
     cudaMemcpy(&h_output, d_output, sizeof(float), cudaMemcpyDeviceToHost);
     assert(h_output == h_price);
 
-    cudaFree(d_price);
-    cudaFree(d_quantity);
     cudaFree(d_output);
     std::cout << "Architecture detection test passed\n";
     return 0;

--- a/tests/jit_error_test.cpp
+++ b/tests/jit_error_test.cpp
@@ -32,8 +32,6 @@ int main() {
     }
     assert(!threw && "Second invocation failed");
 
-    cudaFree(price);
-    cudaFree(quantity);
     cudaFree(output);
     std::cout << "RAII test passed\n";
     return 0;


### PR DESCRIPTION
## Summary
- add ColumnDevicePtr and enhance DeviceBuffer to check cudaFree calls
- migrate Table columns and query helpers to RAII buffers and remove manual frees
- streamline multi-GPU and optimizer paths with automatic device buffer cleanup

## Testing
- `cmake -S . -B build` *(fails: Failed to find nvcc)*
- `apt-get install -y cuda-toolkit-12-1` *(fails: Unable to locate package cuda-toolkit-12-1)*

------
https://chatgpt.com/codex/tasks/task_e_689d274eddbc8328b4712c19b52d1be8