### PR TITLE
Free Arrow C Data capsules

### DIFF
--- a/bindings/python/pywarpdb.cpp
+++ b/bindings/python/pywarpdb.cpp
@@ -25,10 +25,12 @@ PYBIND11_MODULE(pywarpdb, m) {
                 py::capsule array_capsule(arr, [](void *ptr) {
                     ArrowArray *arr = reinterpret_cast<ArrowArray *>(ptr);
                     if (arr->release) arr->release(arr);
+                    delete arr;
                 });
                 py::capsule schema_capsule(schema, [](void *ptr) {
                     ArrowSchema *schema = reinterpret_cast<ArrowSchema *>(ptr);
                     if (schema->release) schema->release(schema);
+                    delete schema;
                 });
                 return py::make_tuple(array_capsule, schema_capsule);
             },


### PR DESCRIPTION
## Summary
- ensure ArrowArray and ArrowSchema capsules delete released objects to avoid memory leaks

## Testing
- `python setup.py build_ext --inplace` *(fails: fatal error: cuda_runtime.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a354d677488328acfe8ab4e7191e80