### PR TITLE
Avoid manual host output deletion

### DIFF
--- a/src/optimizer.cpp
+++ b/src/optimizer.cpp
@@ -162,5 +162,4 @@ void execute_query_optimized(const std::string &expr_part,
         std::cout << "Result[" << i << "] = " << h_out[i] << "\n";
     }
 
-    delete[] h_out;
 }


### PR DESCRIPTION
## Summary
- Remove manual `delete[]` on `std::vector` buffer in `execute_query_optimized`

## Testing
- `cmake -DWARPDB_BUILD_PYTHON=OFF ..` *(fails: Failed to find nvcc)*


------
https://chatgpt.com/codex/tasks/task_e_68a354d5f8408328bfcd2f110cda1bb6