### PR TITLE
Expose configurable JIT kernel block size

### DIFF
--- a/include/jit.hpp
+++ b/include/jit.hpp
@@ -4,10 +4,14 @@
 
 // Compile the given expression and optional condition using NVRTC and launch
 // the generated kernel. Columns are provided via the Table descriptor.
+// Launches a JIT compiled kernel for the given expression and optional
+// condition. `block_size` specifies the CUDA block dimension; when set to 0 the
+// function selects a block size using `cuOccupancyMaxPotentialBlockSize`.
 void jit_compile_and_launch(const std::string &expr_code,
                             const std::string &condition_code,
                             const Table &table,
-                            float *d_output, int device_id = 0);
+                            float *d_output, int device_id = 0,
+                            int block_size = 0);
 
 // JIT compile a kernel that groups rows by `key_expr_code` and sums
 // `val_expr_code`. The number of unique groups is written to d_count and

--- a/src/jit.cpp
+++ b/src/jit.cpp
@@ -9,6 +9,7 @@
 #include <vector>
 #include <unordered_map>
 #include <mutex>
+#include <algorithm>
 
 #define NVRTC_CHECK(stmt)                                                      \
   do {                                                                         \
@@ -108,7 +109,7 @@ std::string compile_cuda_source(const std::string &src,
 void jit_compile_and_launch(const std::string &expr_code,
                             const std::string &condition_code,
                             const Table &table, float *d_output,
-                            int device_id) {
+                            int device_id, int block_size) {
 
   int N = table.num_rows;
 
@@ -179,8 +180,15 @@ void jit_compile_and_launch(const std::string &expr_code,
   args.push_back(&d_output);
   args.push_back(&N);
 
-  int threads = 128;
-  int blocks = (N + threads - 1) / threads;
+  // Determine launch configuration. If block_size is zero, choose an
+  // occupancy-optimised size using cuOccupancyMaxPotentialBlockSize.
+  int threads = block_size;
+  int minGridSize = 0;
+  if (threads <= 0) {
+    CU_CHECK(cuOccupancyMaxPotentialBlockSize(&minGridSize, &threads,
+                                              kernel_func, nullptr, 0, 0));
+  }
+  int blocks = std::max(minGridSize, (N + threads - 1) / threads);
   CU_CHECK(cuLaunchKernel(kernel_func, blocks, 1, 1, threads, 1, 1, 0, 0,
                           args.data(), nullptr));
   CU_CHECK(cuCtxSynchronize());

--- a/src/main.cu
+++ b/src/main.cu
@@ -339,7 +339,10 @@ int main(int argc, char **argv) {
   std::cout << "\n[ JIT Kernel Execution for Expression ]\n";
 
 
-  jit_compile_and_launch(expr_cuda, condition_cuda, table, d_jit_output.get());
+  // Launch with block_size=0 so the kernel chooses an occupancy-based block
+  // configuration.
+  jit_compile_and_launch(expr_cuda, condition_cuda, table, d_jit_output.get(),
+                         0, 0);
 
   std::vector<float> h_jit_output(table.num_rows);
   CUDA_CHECK(cudaMemcpy(h_jit_output.data(), d_jit_output.get(),

--- a/src/multi_gpu_utils.cpp
+++ b/src/multi_gpu_utils.cpp
@@ -13,7 +13,8 @@ std::vector<float> run_multi_gpu_jit_host(const HostTable &host,
     if (device_count < 2) {
         Table dtab = upload_to_gpu(host);
         DeviceBuffer<float> d_out(host.num_rows());
-        jit_compile_and_launch(expr_cuda, cond_cuda, dtab, d_out.get(), 0);
+        // Use block_size=0 to auto-select via occupancy.
+        jit_compile_and_launch(expr_cuda, cond_cuda, dtab, d_out.get(), 0, 0);
         std::vector<float> result(host.num_rows());
         CUDA_CHECK(cudaMemcpy(result.data(), d_out.get(),
                               sizeof(float) * host.num_rows(),
@@ -50,7 +51,8 @@ std::vector<float> run_multi_gpu_jit_host(const HostTable &host,
 
         DeviceBuffer<float> d_out(local_N);
 
-        jit_compile_and_launch(expr_cuda, cond_cuda, dtab, d_out.get(), dev);
+        // Each device launches with block_size=0 for automatic selection.
+        jit_compile_and_launch(expr_cuda, cond_cuda, dtab, d_out.get(), dev, 0);
 
         CUDA_CHECK(cudaMemcpy(results.data() + start, d_out.get(),
                               sizeof(float) * local_N,

--- a/src/optimizer.cpp
+++ b/src/optimizer.cpp
@@ -152,7 +152,9 @@ void execute_query_optimized(const std::string &expr_part,
     }
 
     DeviceBuffer<float> d_output(table.num_rows);
-    jit_compile_and_launch(expr_cuda, cond_cuda, table, d_output.get());
+    // Pass 0 for block_size so jit_compile_and_launch selects an occupancy
+    // optimised configuration.
+    jit_compile_and_launch(expr_cuda, cond_cuda, table, d_output.get(), 0, 0);
 
     std::vector<float> h_out(table.num_rows);
     CUDA_CHECK(cudaMemcpy(h_out.data(), d_output.get(),

--- a/src/warpdb.cpp
+++ b/src/warpdb.cpp
@@ -182,7 +182,10 @@ std::vector<float> WarpDB::query(const std::string &expr) {
 
     DeviceBuffer<float> d_output(table_.num_rows);
 
-    jit_compile_and_launch(expr_cuda, condition_cuda, table_, d_output.get());
+    // block_size=0 lets jit_compile_and_launch pick an occupancy-optimised
+    // value.
+    jit_compile_and_launch(expr_cuda, condition_cuda, table_, d_output.get(), 0,
+                           0);
 
     std::vector<float> result(table_.num_rows);
     CUDA_CHECK(cudaMemcpy(result.data(), d_output.get(),


### PR DESCRIPTION
## Summary
- allow `jit_compile_and_launch` callers to specify CUDA block size and auto-select one via occupancy when set to zero
- update query paths to pass block size and document the occupancy-based behaviour

## Testing
- `./tests/build_no_arrow.sh` *(fails: Failed to find nvcc)*


------
https://chatgpt.com/codex/tasks/task_e_68a354d2c4608328a3ec648c8bcf82fe