### PR TITLE
Add ParsePolicy to JSON loader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,11 @@ add_executable(json_loader_error_test
 target_link_libraries(json_loader_error_test PRIVATE warpdb_lib)
 add_test(NAME json_loader_error_test COMMAND json_loader_error_test)
 
+add_executable(json_loader_permissive_test
+    tests/json_loader_permissive_test.cpp)
+target_link_libraries(json_loader_permissive_test PRIVATE warpdb_lib)
+add_test(NAME json_loader_permissive_test COMMAND json_loader_permissive_test)
+
 
 add_executable(jit_error_test
     tests/jit_error_test.cpp

--- a/include/json_loader.hpp
+++ b/include/json_loader.hpp
@@ -2,5 +2,7 @@
 #include <string>
 #include "csv_loader.hpp" // for HostTable and Table
 
-HostTable load_json_to_host(const std::string &filepath);
-Table load_json_to_gpu(const std::string &filepath);
+HostTable load_json_to_host(const std::string &filepath,
+                            ParsePolicy policy = ParsePolicy::Strict);
+Table load_json_to_gpu(const std::string &filepath,
+                       ParsePolicy policy = ParsePolicy::Strict);

--- a/include/warpdb.hpp
+++ b/include/warpdb.hpp
@@ -11,7 +11,8 @@
 class WarpDB {
 public:
     explicit WarpDB(const std::string &filepath,
-                    const std::vector<DataType> &schema = {});
+                    const std::vector<DataType> &schema = {},
+                    ParsePolicy policy = ParsePolicy::Strict);
     ~WarpDB();
 
     // Execute an expression with optional WHERE clause.

--- a/src/json_loader.cpp
+++ b/src/json_loader.cpp
@@ -7,7 +7,7 @@
 
 #include "cuda_utils.hpp"
 
-HostTable load_json_to_host(const std::string &filepath) {
+HostTable load_json_to_host(const std::string &filepath, ParsePolicy policy) {
   std::ifstream file(filepath);
   if (!file.is_open()) {
     std::cerr << "Failed to open file: " << filepath << std::endl;
@@ -34,13 +34,16 @@ HostTable load_json_to_host(const std::string &filepath) {
     } catch (const std::exception &e) {
       std::cerr << "Error parsing JSON line " << line_num << ": " << e.what()
                 << std::endl;
-      throw std::runtime_error("Failed to parse JSON line");
+      if (policy == ParsePolicy::Strict) {
+        throw std::runtime_error("Failed to parse JSON line");
+      }
+      // Permissive: continue without adding a row
     }
   }
   return host;
 }
 
-Table load_json_to_gpu(const std::string &filepath) {
-  HostTable host = load_json_to_host(filepath);
+Table load_json_to_gpu(const std::string &filepath, ParsePolicy policy) {
+  HostTable host = load_json_to_host(filepath, policy);
   return upload_to_gpu(host);
 }

--- a/src/warpdb.cpp
+++ b/src/warpdb.cpp
@@ -97,18 +97,19 @@ bool eval_condition(const ASTNode *node, const HostTable &table, int idx) {
 
 } // anonymous namespace
 
-WarpDB::WarpDB(const std::string &filepath, const std::vector<DataType> &schema) {
+WarpDB::WarpDB(const std::string &filepath, const std::vector<DataType> &schema,
+               ParsePolicy policy) {
     auto dot = filepath.find_last_of('.');
     std::string ext = dot == std::string::npos ? "" : filepath.substr(dot + 1);
     for (auto &c : ext) c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
 
     if (ext == "csv") {
-        table_ = load_csv_to_gpu(filepath, schema);
-        host_table_ = load_csv_to_host(filepath, schema);
+        table_ = load_csv_to_gpu(filepath, schema, policy);
+        host_table_ = load_csv_to_host(filepath, schema, policy);
     } else if (ext == "json") {
-        table_ = load_json_to_gpu(filepath);
+        table_ = load_json_to_gpu(filepath, policy);
 
-        host_table_ = load_json_to_host(filepath);
+        host_table_ = load_json_to_host(filepath, policy);
 
 #ifdef USE_ARROW
 

--- a/tests/json_loader_error_test.cpp
+++ b/tests/json_loader_error_test.cpp
@@ -5,7 +5,7 @@
 int main() {
   bool threw = false;
   try {
-    load_json_to_host("data/malformed.json");
+    load_json_to_host("data/malformed.json", ParsePolicy::Strict);
   } catch (const std::runtime_error &) {
     threw = true;
     std::cout << "Caught JSON parse error\n";

--- a/tests/json_loader_permissive_test.cpp
+++ b/tests/json_loader_permissive_test.cpp
@@ -1,0 +1,17 @@
+#include "json_loader.hpp"
+#include <cassert>
+#include <iostream>
+
+int main() {
+  bool threw = false;
+  HostTable table;
+  try {
+    table = load_json_to_host("data/malformed.json", ParsePolicy::Permissive);
+  } catch (const std::runtime_error &) {
+    threw = true;
+  }
+  assert(!threw && "Permissive policy should not throw");
+  assert(table.num_rows() == 2 && "Expected 2 valid rows");
+  std::cout << "json loader permissive test passed\n";
+  return 0;
+}


### PR DESCRIPTION
## Summary
- support configurable ParsePolicy in JSON loader and WarpDB constructor
- log or throw on JSON parse errors based on policy
- test JSON loader behavior in strict and permissive modes

## Testing
- `cmake -S . -B build` *(fails: Failed to find nvcc)*
- `apt-get install -y nvidia-cuda-toolkit` *(fails: ca-certificates-java post-installation error)*

------
https://chatgpt.com/codex/tasks/task_e_68a354d494a083289d8225a3d88b5a8b