### PR TITLE
Use from_chars for CSV chunk parsing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,11 @@ add_executable(csv_loader_error_test
 target_link_libraries(csv_loader_error_test PRIVATE warpdb_lib)
 add_test(NAME csv_loader_error_test COMMAND csv_loader_error_test)
 
+add_executable(csv_loader_chunk_error_test
+    tests/csv_loader_chunk_error_test.cpp)
+target_link_libraries(csv_loader_chunk_error_test PRIVATE warpdb_lib)
+add_test(NAME csv_loader_chunk_error_test COMMAND csv_loader_chunk_error_test)
+
 add_executable(json_loader_error_test
     tests/json_loader_error_test.cpp)
 target_link_libraries(json_loader_error_test PRIVATE warpdb_lib)

--- a/src/csv_loader.cpp
+++ b/src/csv_loader.cpp
@@ -283,18 +283,23 @@ HostTable load_csv_chunk(std::istream &stream, int max_rows, bool &finished,
     std::string val;
     for (size_t i = 0; i < names.size(); ++i) {
       if (!std::getline(ss, val, ',')) val.clear();
-      try {
-        std::get<std::vector<float>>(table.columns[i].data).push_back(std::stof(val));
-      } catch (const std::exception &e) {
+      float parsed = 0.0f;
+      auto [ptr, ec] =
+          std::from_chars(val.data(), val.data() + val.size(), parsed,
+                          std::chars_format::general);
+      if (ec != std::errc() || ptr != val.data() + val.size()) {
+        std::error_code code = std::make_error_code(ec);
         std::cerr << "Failed to parse float value '" << val
                   << "' at row " << (count + 1) << " column '"
-                  << table.columns[i].name << "': " << e.what()
+                  << table.columns[i].name << "': " << code.message()
                   << std::endl;
         if (policy == ParsePolicy::Permissive) {
           std::get<std::vector<float>>(table.columns[i].data).push_back(0.0f);
         } else {
-          throw;
+          throw std::runtime_error("Invalid float");
         }
+      } else {
+        std::get<std::vector<float>>(table.columns[i].data).push_back(parsed);
       }
     }
     ++count;

--- a/tests/csv_loader_chunk_error_test.cpp
+++ b/tests/csv_loader_chunk_error_test.cpp
@@ -1,0 +1,37 @@
+#include "csv_loader.hpp"
+#include <cassert>
+#include <sstream>
+#include <iostream>
+
+int main() {
+    std::string data =
+        "price,quantity\n"
+        "1.0,2.0\n"
+        "foo,3.0\n"
+        "1e39,4.0\n";
+    std::istringstream ss(data);
+    bool finished = false;
+    bool threw = false;
+    try {
+        load_csv_chunk(ss, 10, finished);
+    } catch (const std::exception &) {
+        threw = true;
+    }
+    assert(threw && "Expected strict parsing to throw");
+
+    std::istringstream ss_perm(data);
+    finished = false;
+    HostTable table = load_csv_chunk(ss_perm, 10, finished, ParsePolicy::Permissive);
+    const auto &price = std::get<std::vector<float>>(table.columns[0].data);
+    const auto &quantity = std::get<std::vector<float>>(table.columns[1].data);
+    assert(price.size() == 3 && quantity.size() == 3);
+    assert(price[0] == 1.0f);
+    assert(price[1] == 0.0f);
+    assert(price[2] == 0.0f);
+    assert(quantity[0] == 2.0f);
+    assert(quantity[1] == 3.0f);
+    assert(quantity[2] == 4.0f);
+
+    std::cout << "csv loader chunk error test passed\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary
- replace `std::stof` with `std::from_chars` in `load_csv_chunk`
- handle float conversion errors through `ParsePolicy`
- add a test for chunk parsing error handling

## Testing
- `cmake -S . -B build` *(fails: Failed to find nvcc)*
- `apt-get install -y nvidia-cuda-toolkit` *(fails: ca-certificates-java post-installation script error)*

------
https://chatgpt.com/codex/tasks/task_e_68a354d3fc1c832885fbf2e5bea9bfd2