### PR TITLE
Expose Python binding options and query_sql

### DIFF
--- a/bindings/python/pywarpdb.cpp
+++ b/bindings/python/pywarpdb.cpp
@@ -5,9 +5,25 @@
 namespace py = pybind11;
 
 PYBIND11_MODULE(pywarpdb, m) {
+    py::enum_<DataType>(m, "DataType")
+        .value("Int32", DataType::Int32)
+        .value("Int64", DataType::Int64)
+        .value("Float32", DataType::Float32)
+        .value("Float64", DataType::Float64)
+        .value("String", DataType::String);
+
+    py::enum_<ParsePolicy>(m, "ParsePolicy")
+        .value("Strict", ParsePolicy::Strict)
+        .value("Permissive", ParsePolicy::Permissive);
+
     py::class_<WarpDB>(m, "WarpDB")
-        .def(py::init<const std::string &>())
-        .def("query", &WarpDB::query)
+        .def(py::init<const std::string &, const std::vector<DataType>&, ParsePolicy>(),
+             py::arg("filepath"),
+             py::arg("schema") = std::vector<DataType>(),
+             py::arg("policy") = ParsePolicy::Strict)
+        .def("query", &WarpDB::query, py::arg("expr"))
+        .def("query_sql", &WarpDB::query_sql, py::arg("sql"),
+             R"pbdoc(Execute a full SQL query supporting GROUP BY and ORDER BY.)pbdoc")
         .def("query_multi_gpu", &WarpDB::query_multi_gpu,
              py::arg("expr"),
              R"pbdoc(Execute expression using all available GPUs on the current table.)pbdoc")

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1,13 +1,28 @@
 import csv
 import pywarpdb
 
-db = pywarpdb.WarpDB("data/test.csv")
-result = db.query("price + 1")
+# Constructor with explicit schema and parse policy
+schema = [pywarpdb.DataType.Float32, pywarpdb.DataType.Int32]
+db = pywarpdb.WarpDB("data/test.csv", schema, pywarpdb.ParsePolicy.Strict)
 
+# Simple expression query
+result = db.query("price + 1")
 with open("data/test.csv", newline="") as f:
     reader = csv.DictReader(f)
     expected = [float(row["price"]) + 1 for row in reader]
-
 assert len(result) == len(expected)
 assert result == expected
+
+# SQL query
+sql_res = db.query_sql("SELECT price FROM test ORDER BY price ASC")
+with open("data/test.csv", newline="") as f:
+    reader = csv.DictReader(f)
+    expected_sql = sorted(float(row["price"]) for row in reader)
+assert sql_res == expected_sql
+
+# Permissive parse policy handles malformed rows
+malformed_schema = [pywarpdb.DataType.Float32, pywarpdb.DataType.Int32]
+db_perm = pywarpdb.WarpDB("data/malformed.csv", malformed_schema, pywarpdb.ParsePolicy.Permissive)
+perm_res = db_perm.query("price + quantity")
+assert perm_res == [11.5, 20.0, 2.5]
 


### PR DESCRIPTION
## Summary
- add DataType and ParsePolicy enums to Python API
- allow WarpDB constructor to accept optional schema and parse policy
- expose query_sql method and expand Python tests

## Testing
- `python setup.py build_ext --inplace` *(fails: fatal error: cuda_runtime.h: No such file or directory)*
- `python -m pytest tests/test_python.py` *(fails: ModuleNotFoundError: No module named 'pywarpdb')*

------
https://chatgpt.com/codex/tasks/task_e_68b1eada252483288809a45adfaf835f