### PR TITLE
Propagate NVRTC compile logs in JIT errors

### DIFF
--- a/src/jit.cpp
+++ b/src/jit.cpp
@@ -95,7 +95,7 @@ std::string compile_cuda_source(const std::string &src,
   nvrtcGetProgramLog(prog.prog, &log[0]);
   if (compileResult != NVRTC_SUCCESS) {
     std::cerr << "NVRTC Compile Log:\n" << log << "\n";
-    throw std::runtime_error("Kernel compilation failed.");
+    throw std::runtime_error("Kernel compilation failed.\n" + log);
   }
   size_t ptxSize;
   NVRTC_CHECK(nvrtcGetPTXSize(prog.prog, &ptxSize));

--- a/tests/jit_compile_log_test.cpp
+++ b/tests/jit_compile_log_test.cpp
@@ -1,0 +1,35 @@
+#include "jit.hpp"
+#include <cuda_runtime.h>
+#include <cassert>
+#include <iostream>
+#include <stdexcept>
+
+int main() {
+    float *price; cudaMalloc(&price, sizeof(float));
+    int *quantity; cudaMalloc(&quantity, sizeof(int));
+    float *output; cudaMalloc(&output, sizeof(float));
+
+    Table table;
+    table.num_rows = 1;
+    table.columns.push_back({"price", DataType::Float32, price, 1});
+    table.columns.push_back({"quantity", DataType::Int32, quantity, 1});
+
+    bool threw = false;
+    try {
+        // invalid code will fail to compile and include log in the error
+        jit_compile_and_launch("invalid@", "", table, output);
+    } catch (const std::runtime_error &e) {
+        threw = true;
+        std::string msg = e.what();
+        assert(msg.find("error:") != std::string::npos &&
+               "Expected compile log in error message");
+    }
+    assert(threw && "Expected compilation to fail");
+
+    cudaFree(price);
+    cudaFree(quantity);
+    cudaFree(output);
+
+    std::cout << "JIT compile log test passed\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary
- include NVRTC compile log in thrown runtime_error for JIT compilation failures
- add regression test asserting compile log text surfaces in error message

## Testing
- `./tests/build_no_arrow.sh` *(fails: Failed to find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_68b1eadcb34083289a12efe0e45f9114