### PR TITLE
Refactor evaluation with templated helper and add tests

### DIFF
--- a/include/eval_helpers.hpp
+++ b/include/eval_helpers.hpp
@@ -1,0 +1,53 @@
+#pragma once
+#include "csv_loader.hpp"
+#include "expression.hpp"
+#include <string>
+
+inline float get_value(const HostTable &table, const std::string &name, int idx) {
+    const HostColumn *col = table.get_column(name);
+    if (!col) return 0.0f;
+    switch (col->type) {
+    case DataType::Int32:
+        return static_cast<float>(std::get<std::vector<int32_t>>(col->data)[idx]);
+    case DataType::Int64:
+        return static_cast<float>(std::get<std::vector<int64_t>>(col->data)[idx]);
+    case DataType::Float32:
+        return std::get<std::vector<float>>(col->data)[idx];
+    case DataType::Float64:
+        return static_cast<float>(std::get<std::vector<double>>(col->data)[idx]);
+    default:
+        return 0.0f;
+    }
+}
+
+template <typename Context>
+float eval_node(const ASTNode *node, const Context &ctx, int idx) {
+    if (auto c = dynamic_cast<const ConstantNode *>(node)) {
+        return std::stof(c->value);
+    }
+    if (auto v = dynamic_cast<const VariableNode *>(node)) {
+        return get_value(ctx, v->name, idx);
+    }
+    if (auto b = dynamic_cast<const BinaryOpNode *>(node)) {
+        float l = eval_node(b->left.get(), ctx, idx);
+        float r = eval_node(b->right.get(), ctx, idx);
+        const std::string &op = b->op;
+        if (op == "+") return l + r;
+        if (op == "-") return l - r;
+        if (op == "*") return l * r;
+        if (op == "/") return l / r;
+        if (op == ">") return l > r;
+        if (op == "<") return l < r;
+        if (op == ">=") return l >= r;
+        if (op == "<=") return l <= r;
+        if (op == "==") return l == r;
+        if (op == "!=") return l != r;
+    }
+    return 0.0f;
+}
+
+template <typename Context>
+bool eval_condition(const ASTNode *node, const Context &ctx, int idx) {
+    return eval_node(node, ctx, idx) != 0.0f;
+}
+

--- a/src/warpdb.cpp
+++ b/src/warpdb.cpp
@@ -14,6 +14,7 @@
 #include <stdexcept>
 #include <unordered_set>
 #include <memory>
+#include "eval_helpers.hpp"
 
 
 namespace {
@@ -46,56 +47,6 @@ void validate_ast(const ASTNode *node,
 }
 
 } // namespace
-
-namespace {
-
-float get_value(const HostTable &table, const std::string &name, int idx) {
-    const HostColumn *col = table.get_column(name);
-    if (!col) return 0.0f;
-    switch (col->type) {
-    case DataType::Int32:
-        return static_cast<float>(std::get<std::vector<int32_t>>(col->data)[idx]);
-    case DataType::Int64:
-        return static_cast<float>(std::get<std::vector<int64_t>>(col->data)[idx]);
-    case DataType::Float32:
-        return std::get<std::vector<float>>(col->data)[idx];
-    case DataType::Float64:
-        return static_cast<float>(std::get<std::vector<double>>(col->data)[idx]);
-    default:
-        return 0.0f;
-    }
-}
-
-float eval_node(const ASTNode *node, const HostTable &table, int idx) {
-    if (auto c = dynamic_cast<const ConstantNode *>(node)) {
-        return std::stof(c->value);
-    }
-    if (auto v = dynamic_cast<const VariableNode *>(node)) {
-        return get_value(table, v->name, idx);
-    }
-    if (auto b = dynamic_cast<const BinaryOpNode *>(node)) {
-        float l = eval_node(b->left.get(), table, idx);
-        float r = eval_node(b->right.get(), table, idx);
-        const std::string &op = b->op;
-        if (op == "+") return l + r;
-        if (op == "-") return l - r;
-        if (op == "*") return l * r;
-        if (op == "/") return l / r;
-        if (op == ">") return l > r;
-        if (op == "<") return l < r;
-        if (op == ">=") return l >= r;
-        if (op == "<=") return l <= r;
-        if (op == "==") return l == r;
-        if (op == "!=") return l != r;
-    }
-    return 0.0f;
-}
-
-bool eval_condition(const ASTNode *node, const HostTable &table, int idx) {
-    return eval_node(node, table, idx) != 0.0f;
-}
-
-} // anonymous namespace
 
 WarpDB::WarpDB(const std::string &filepath, const std::vector<DataType> &schema,
                ParsePolicy policy) {
@@ -196,42 +147,6 @@ std::vector<float> WarpDB::query(const std::string &expr) {
 }
 
 
-
-namespace {
-struct Row { float price; int quantity; };
-
-float eval_node(const ASTNode *node, const Row &r) {
-    if (auto c = dynamic_cast<const ConstantNode *>(node)) {
-        return std::stof(c->value);
-    }
-    if (auto v = dynamic_cast<const VariableNode *>(node)) {
-        if (v->name == "price") return r.price;
-        if (v->name == "quantity") return static_cast<float>(r.quantity);
-        return 0.0f;
-    }
-    if (auto b = dynamic_cast<const BinaryOpNode *>(node)) {
-        float l = eval_node(b->left.get(), r);
-        float rr = eval_node(b->right.get(), r);
-        const std::string &op = b->op;
-        if (op == "+") return l + rr;
-        if (op == "-") return l - rr;
-        if (op == "*") return l * rr;
-        if (op == "/") return l / rr;
-        if (op == ">") return l > rr;
-        if (op == "<") return l < rr;
-        if (op == ">=") return l >= rr;
-        if (op == "<=") return l <= rr;
-        if (op == "==") return l == rr;
-        if (op == "!=") return l != rr;
-    }
-    return 0.0f;
-}
-
-bool eval_condition(const ASTNode *node, const Row &r) {
-    return eval_node(node, r) != 0.0f;
-}
-
-} // namespace
 
 // Helper utilities for query_sql
 namespace {

--- a/tests/eval_helper_test.cpp
+++ b/tests/eval_helper_test.cpp
@@ -1,0 +1,56 @@
+#include "expression.hpp"
+#include "csv_loader.hpp"
+#include "eval_helpers.hpp"
+#include <cassert>
+#include <cmath>
+#include <iostream>
+
+struct TestRow {
+    float price;
+    int quantity;
+};
+
+float get_value(const TestRow &r, const std::string &name, int) {
+    if (name == "price") return r.price;
+    if (name == "quantity") return static_cast<float>(r.quantity);
+    return 0.0f;
+}
+
+int main() {
+    HostColumn price;
+    price.name = "price";
+    price.type = DataType::Float32;
+    price.data = std::vector<float>{10.0f, 5.0f};
+
+    HostColumn quantity;
+    quantity.name = "quantity";
+    quantity.type = DataType::Int32;
+    quantity.data = std::vector<int32_t>{2, 3};
+
+    HostTable table;
+    table.columns = {price, quantity};
+
+    auto expr_tokens = tokenize("price * quantity + 1");
+    auto expr_ast = parse_expression(expr_tokens);
+
+    auto cond_tokens = tokenize("price > 7");
+    auto cond_ast = parse_expression(cond_tokens);
+
+    const auto &prices = std::get<std::vector<float>>(table.columns[0].data);
+    const auto &qtys = std::get<std::vector<int32_t>>(table.columns[1].data);
+
+    for (int i = 0; i < table.num_rows(); ++i) {
+        TestRow r{prices[i], qtys[i]};
+        float table_val = eval_node(expr_ast.get(), table, i);
+        float row_val = eval_node(expr_ast.get(), r, 0);
+        assert(std::fabs(table_val - row_val) < 1e-5);
+
+        bool table_cond = eval_condition(cond_ast.get(), table, i);
+        bool row_cond = eval_condition(cond_ast.get(), r, 0);
+        assert(table_cond == row_cond);
+    }
+
+    std::cout << "All tests passed\n";
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- Introduce generic eval helper with `get_value` to share node evaluation logic
- Simplify warpdb.cpp to rely on the templated eval functions
- Add tests covering host-table and row-style contexts

## Testing
- `g++ -std=c++17 tests/eval_helper_test.cpp src/expression.cpp -Iinclude -Itests/stubs -o tests/eval_helper_test`
- `./tests/eval_helper_test`
- `g++ -std=c++17 tests/test_expression.cpp src/expression.cpp -Iinclude -o tests/test_expression -Itests/stubs`
- `./tests/test_expression`


------
https://chatgpt.com/codex/tasks/task_e_68b1eae3b32c83288897d0ca550438bb