### PR TITLE
Adjust limit/offset application order and expand tests

### DIFF
--- a/src/warpdb.cpp
+++ b/src/warpdb.cpp
@@ -305,13 +305,16 @@ void apply_order_by(const QueryAST &ast, const HostTable &table,
 }
 
 void apply_limit_offset(const QueryAST &ast, std::vector<float> &result) {
-    if (ast.limit && static_cast<size_t>(ast.limit->count) < result.size()) {
-        result.resize(ast.limit->count);
-    }
     if (ast.offset) {
         size_t off = static_cast<size_t>(ast.offset->count);
-        if (off >= result.size()) result.clear();
-        else result.erase(result.begin(), result.begin() + off);
+        if (off >= result.size()) {
+            result.clear();
+            return;
+        }
+        result.erase(result.begin(), result.begin() + off);
+    }
+    if (ast.limit && static_cast<size_t>(ast.limit->count) < result.size()) {
+        result.resize(ast.limit->count);
     }
 }
 

--- a/tests/sql_features_test.cpp
+++ b/tests/sql_features_test.cpp
@@ -35,8 +35,25 @@ int main(){
 
 
     auto offset = db.query_sql("SELECT price FROM test ORDER BY price DESC LIMIT 2 OFFSET 1");
-    assert(offset.size() == 1);
+    assert(offset.size() == 2);
     assert(std::abs(offset[0] - prices[1]) < 1e-5);
+    assert(std::abs(offset[1] - prices[2]) < 1e-5);
+
+    auto offset_only = db.query_sql("SELECT price FROM test ORDER BY price DESC OFFSET 2");
+    assert(offset_only.size() == 2);
+    assert(std::abs(offset_only[0] - prices[2]) < 1e-5);
+    assert(std::abs(offset_only[1] - prices[3]) < 1e-5);
+
+    auto offset_then_limit = db.query_sql("SELECT price FROM test ORDER BY price DESC LIMIT 1 OFFSET 2");
+    assert(offset_then_limit.size() == 1);
+    assert(std::abs(offset_then_limit[0] - prices[2]) < 1e-5);
+
+    auto large_limit = db.query_sql("SELECT price FROM test ORDER BY price DESC LIMIT 5 OFFSET 3");
+    assert(large_limit.size() == 1);
+    assert(std::abs(large_limit[0] - prices[3]) < 1e-5);
+
+    auto offset_beyond = db.query_sql("SELECT price FROM test ORDER BY price DESC LIMIT 2 OFFSET 10");
+    assert(offset_beyond.empty());
 
     auto having = db.query_sql("SELECT SUM(price) FROM test GROUP BY quantity HAVING SUM(price) > 15 ORDER BY quantity ASC");
     assert(having.size() == 3);


### PR DESCRIPTION
## Summary
- reorder SQL LIMIT/OFFSET processing to discard offset rows before applying limits
- broaden sql_features_test coverage with multiple LIMIT and OFFSET combinations to match SQL behavior

## Testing
- cmake -S . -B build *(fails: missing CUDA toolkit in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d82c35d6088328bf00f8cce8a6b041