### PR TITLE
Preserve floating point group by keys

### DIFF
--- a/src/warpdb.cpp
+++ b/src/warpdb.cpp
@@ -243,9 +243,10 @@ std::vector<float> execute_group_by(const QueryAST &ast,
     auto *agg = dynamic_cast<AggregationNode *>(ast.select_list[0].get());
     if (!agg) throw std::runtime_error("Only aggregation queries supported with GROUP BY");
 
-    std::unordered_map<int, AggData> groups;
+    std::unordered_map<double, AggData> groups;
     for (int idx : rows) {
-        int key = static_cast<int>(eval_node(ast.group_by->keys[0].get(), table, idx));
+        double key = static_cast<double>(
+            eval_node(ast.group_by->keys[0].get(), table, idx));
         float val = 1.0f;
         if (agg->agg != AggregationType::Count) {
             val = eval_node(agg->expr.get(), table, idx);
@@ -258,7 +259,7 @@ std::vector<float> execute_group_by(const QueryAST &ast,
         g.max = std::max(g.max, static_cast<double>(val));
     }
 
-    std::vector<std::pair<float,float>> keyed;
+    std::vector<std::pair<double,float>> keyed;
     for (const auto &kv : groups) {
         const AggData &g = kv.second;
         if (!eval_having(ast, g)) continue;
@@ -271,8 +272,7 @@ std::vector<float> execute_group_by(const QueryAST &ast,
         case AggregationType::Min: out = g.min; break;
         case AggregationType::Max: out = g.max; break;
         }
-        float key = static_cast<float>(kv.first);
-        keyed.push_back({key, out});
+        keyed.push_back({kv.first, out});
     }
 
     if (ast.order_by) {

--- a/tests/sql_features_test.cpp
+++ b/tests/sql_features_test.cpp
@@ -41,5 +41,30 @@ int main(){
     auto having = db.query_sql("SELECT SUM(price) FROM test GROUP BY quantity HAVING SUM(price) > 15 ORDER BY quantity ASC");
     assert(having.size() == 3);
 
+    auto float_group = db.query_sql(
+        "SELECT SUM(price) FROM test GROUP BY price / 10.0 ORDER BY price / 10.0 ASC");
+    std::map<double, double> float_groups;
+    for (size_t i = 0; i < prices_vec.size(); ++i) {
+        double key = static_cast<double>(prices_vec[i]) / 10.0;
+        float_groups[key] += prices_vec[i];
+    }
+    std::vector<float> expected_float;
+    for (const auto &kv : float_groups) {
+        expected_float.push_back(static_cast<float>(kv.second));
+    }
+
+    assert(float_group.size() == expected_float.size());
+    for (size_t i = 0; i < expected_float.size(); ++i) {
+        assert(std::abs(float_group[i] - expected_float[i]) < 1e-5);
+    }
+
+    auto float_group_desc = db.query_sql(
+        "SELECT SUM(price) FROM test GROUP BY price / 10.0 ORDER BY price / 10.0 DESC");
+    std::vector<float> expected_desc(expected_float.rbegin(), expected_float.rend());
+    assert(float_group_desc.size() == expected_desc.size());
+    for (size_t i = 0; i < expected_desc.size(); ++i) {
+        assert(std::abs(float_group_desc[i] - expected_desc[i]) < 1e-5);
+    }
+
     return 0;
 }


### PR DESCRIPTION
## Summary
- update GROUP BY execution to retain the full evaluated key value instead of truncating to integers
- adjust ordering logic to use the preserved floating-point keys
- extend SQL feature tests to cover grouping by non-integer expressions

## Testing
- cmake -S . -B build-no-arrow -DCMAKE_DISABLE_FIND_PACKAGE_Arrow=ON *(fails: environment lacks CUDA toolkit)*

------
https://chatgpt.com/codex/tasks/task_e_68d82c3699fc8328a58df74f25ef77d6