### PR TITLE
Ensure CSV chunk loader reuses parsed headers

### DIFF
--- a/include/csv_loader.hpp
+++ b/include/csv_loader.hpp
@@ -103,8 +103,11 @@ HostTable load_csv_to_host(const std::string &filepath,
                            ParsePolicy policy = ParsePolicy::Strict);
 Table upload_to_gpu(const HostTable &table);
 
-// Load at most `max_rows` CSV rows from an open input stream. `finished`
-// will be set to true when no more rows are available.
+// Load at most `max_rows` CSV rows from an open input stream using the provided
+// `column_names`. The header should be consumed by the caller so the loader
+// does not re-read or skip the first data row. `finished` will be set to true
+// when no more rows are available.
 HostTable load_csv_chunk(std::istream &stream, int max_rows, bool &finished,
+                         const std::vector<std::string> &column_names,
                          ParsePolicy policy = ParsePolicy::Strict);
 

--- a/src/csv_loader.cpp
+++ b/src/csv_loader.cpp
@@ -296,25 +296,27 @@ Table load_csv_to_gpu(const std::string &filepath) {
 }
 
 HostTable load_csv_chunk(std::istream &stream, int max_rows, bool &finished,
+                         const std::vector<std::string> &column_names,
                          ParsePolicy policy) {
-  std::string header;
-  std::streampos pos = stream.tellg();
-  if (!(stream >> header)) {
+  if (column_names.empty())
+    throw std::runtime_error("No column names provided for CSV chunk load");
+
+  if (stream.bad())
+    throw std::runtime_error("CSV stream is in a bad state");
+
+  if (stream.eof()) {
     finished = true;
     return {};
   }
-  stream.seekg(pos);
 
-  std::getline(stream, header);
-  std::stringstream hs(header);
-  std::vector<std::string> names;
-  std::string tmp;
-  while (std::getline(hs, tmp, ',')) names.push_back(tmp);
+  if (stream.fail()) {
+    stream.clear();
+  }
 
   HostTable table;
-  table.columns.resize(names.size());
-  for (size_t i = 0; i < names.size(); ++i) {
-    table.columns[i].name = names[i];
+  table.columns.resize(column_names.size());
+  for (size_t i = 0; i < column_names.size(); ++i) {
+    table.columns[i].name = column_names[i];
     table.columns[i].type = DataType::Float32;
     table.columns[i].data = std::vector<float>();
   }
@@ -325,7 +327,7 @@ HostTable load_csv_chunk(std::istream &stream, int max_rows, bool &finished,
     if (line.empty()) continue;
     std::stringstream ss(line);
     std::string val;
-    for (size_t i = 0; i < names.size(); ++i) {
+    for (size_t i = 0; i < column_names.size(); ++i) {
       if (!std::getline(ss, val, ',')) val.clear();
       val.erase(val.begin(),
                 std::find_if(val.begin(), val.end(),
@@ -358,6 +360,6 @@ HostTable load_csv_chunk(std::istream &stream, int max_rows, bool &finished,
   if (stream.fail() && !stream.eof()) {
     throw std::runtime_error("Error reading CSV: partial line or I/O error");
   }
-  finished = stream.peek() == EOF;
+  finished = stream.eof();
   return table;
 }

--- a/src/main.cu
+++ b/src/main.cu
@@ -4,6 +4,7 @@
 #include <fstream>
 #include <memory>
 #include <vector>
+#include <sstream>
 
 #include "csv_loader.hpp"
 #include "expression.hpp"
@@ -36,12 +37,27 @@ void run_multi_gpu_jit_large(const std::string &csv_path,
   }
 
   std::string header;
-  std::getline(file, header);
+  if (!std::getline(file, header)) {
+    std::cerr << "Empty CSV file: " << csv_path << "\n";
+    return;
+  }
+
+  std::stringstream header_stream(header);
+  std::vector<std::string> column_names;
+  std::string column_name;
+  while (std::getline(header_stream, column_name, ',')) {
+    column_names.push_back(column_name);
+  }
+  if (column_names.empty()) {
+    std::cerr << "Failed to parse header for: " << csv_path << "\n";
+    return;
+  }
 
   bool finished = false;
   std::vector<float> all_results;
   while (!finished) {
-    HostTable chunk = load_csv_chunk(file, rows_per_chunk, finished);
+    HostTable chunk = load_csv_chunk(file, rows_per_chunk, finished, column_names);
+    if (chunk.num_rows() == 0) continue;
     auto part = run_multi_gpu_jit_host(chunk, expr_cuda, cond_cuda);
     all_results.insert(all_results.end(), part.begin(), part.end());
   }

--- a/src/warpdb.cpp
+++ b/src/warpdb.cpp
@@ -5,6 +5,8 @@
 #include <cctype>
 #include <iostream>
 #include <fstream>
+#include <sstream>
+#include <vector>
 
 #include <map>
 #include <unordered_map>
@@ -434,12 +436,27 @@ std::vector<float> WarpDB::query_multi_gpu_csv(const std::string &csv_path,
     }
 
     std::string header;
-    std::getline(file, header);
+    if (!std::getline(file, header)) {
+        throw std::runtime_error("Empty CSV file: " + csv_path);
+    }
+
+    std::stringstream header_stream(header);
+    std::vector<std::string> column_names;
+    std::string column_name;
+    while (std::getline(header_stream, column_name, ',')) {
+        column_names.push_back(column_name);
+    }
+    if (column_names.empty()) {
+        throw std::runtime_error("Failed to parse CSV header for: " + csv_path);
+    }
 
     bool finished = false;
     std::vector<float> all_results;
     while (!finished) {
-        HostTable chunk = load_csv_chunk(file, rows_per_chunk, finished);
+        HostTable chunk = load_csv_chunk(file, rows_per_chunk, finished, column_names);
+        if (chunk.num_rows() == 0) {
+            continue;
+        }
         auto part = run_multi_gpu_jit_host(chunk, expr_cuda, condition_cuda);
         all_results.insert(all_results.end(), part.begin(), part.end());
     }

--- a/tests/csv_loader_chunk_error_test.cpp
+++ b/tests/csv_loader_chunk_error_test.cpp
@@ -1,6 +1,7 @@
 #include "csv_loader.hpp"
 #include <cassert>
 #include <sstream>
+#include <vector>
 #include <iostream>
 
 int main() {
@@ -10,18 +11,28 @@ int main() {
         "foo,3.0\n"
         "1e39,4.0\n";
     std::istringstream ss(data);
+    std::string header_line;
+    std::getline(ss, header_line);
+    std::stringstream header_stream(header_line);
+    std::vector<std::string> columns;
+    std::string column_name;
+    while (std::getline(header_stream, column_name, ',')) {
+        columns.push_back(column_name);
+    }
     bool finished = false;
     bool threw = false;
     try {
-        load_csv_chunk(ss, 10, finished);
+        load_csv_chunk(ss, 10, finished, columns);
     } catch (const std::exception &) {
         threw = true;
     }
     assert(threw && "Expected strict parsing to throw");
 
     std::istringstream ss_perm(data);
+    std::getline(ss_perm, header_line);
     finished = false;
-    HostTable table = load_csv_chunk(ss_perm, 10, finished, ParsePolicy::Permissive);
+    HostTable table = load_csv_chunk(ss_perm, 10, finished, columns,
+                                    ParsePolicy::Permissive);
     const auto &price = std::get<std::vector<float>>(table.columns[0].data);
     const auto &quantity = std::get<std::vector<float>>(table.columns[1].data);
     assert(price.size() == 3 && quantity.size() == 3);

--- a/tests/csv_loader_chunk_test.cpp
+++ b/tests/csv_loader_chunk_test.cpp
@@ -1,6 +1,7 @@
 #include "csv_loader.hpp"
 #include <cassert>
 #include <sstream>
+#include <vector>
 #include <iostream>
 
 int main() {
@@ -8,13 +9,21 @@ int main() {
         "price,quantity\n"
         " 10.5 , 3 \n"
         " 20.0, 4\n"
-        "price,quantity\n"
         " 15.25 , 2 \n"
         " 30.0 , 5 \n";
     std::istringstream ss(data);
 
+    std::string header_line;
+    std::getline(ss, header_line);
+    std::stringstream header_stream(header_line);
+    std::vector<std::string> columns;
+    std::string column_name;
+    while (std::getline(header_stream, column_name, ',')) {
+        columns.push_back(column_name);
+    }
+
     bool finished = false;
-    HostTable first = load_csv_chunk(ss, 2, finished);
+    HostTable first = load_csv_chunk(ss, 2, finished, columns);
     assert(first.num_rows() == 2);
     const auto &p1 = std::get<std::vector<float>>(first.columns[0].data);
     const auto &q1 = std::get<std::vector<float>>(first.columns[1].data);
@@ -22,7 +31,7 @@ int main() {
     assert(q1[0] == 3.0f && q1[1] == 4.0f);
     assert(!finished);
 
-    HostTable second = load_csv_chunk(ss, 2, finished);
+    HostTable second = load_csv_chunk(ss, 2, finished, columns);
     assert(second.num_rows() == 2);
     const auto &p2 = std::get<std::vector<float>>(second.columns[0].data);
     const auto &q2 = std::get<std::vector<float>>(second.columns[1].data);


### PR DESCRIPTION
## Summary
- update the CSV chunk loader to accept caller-provided column names so the first data row is not consumed
- parse the header once when streaming CSV files for multi-GPU queries and pass the names into the chunk loader
- extend CSV chunk loader tests to validate multi-chunk ingestion retains the first data row

## Testing
- cmake -S . -B build *(fails: nvcc not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d82c33916c8328965aa56c2f196719