### PR TITLE
Auto-fetch pinned nlohmann/json header for Python packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,12 @@ You can also install the module directly from the source tree:
 pip install .
 ```
 
+During Python builds, `setup.py` automatically downloads the pinned
+`nlohmann/json` header (`v3.2.0`, matching the CMake `FetchContent` pin) into a
+local build dependency directory and adds that include path before compiling the
+`Pybind11Extension`. Python-only builders do not need to pre-install
+`nlohmann/json`.
+
 Or build a wheel for redistribution:
 
 ```bash

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,46 @@
 from glob import glob
+from pathlib import Path
+from urllib.request import urlopen
+
 from setuptools import setup
 from pybind11.setup_helpers import Pybind11Extension, build_ext
+
+
+NLOHMANN_JSON_VERSION = 'v3.2.0'
+NLOHMANN_JSON_URLS = [
+    f'https://raw.githubusercontent.com/nlohmann/json/{NLOHMANN_JSON_VERSION}/single_include/nlohmann/json.hpp',
+    f'https://raw.githubusercontent.com/nlohmann/json/{NLOHMANN_JSON_VERSION}/include/nlohmann/json.hpp',
+]
+
+
+def ensure_nlohmann_json_header(base_dir: Path) -> str:
+    include_dir = base_dir / 'nlohmann_json' / NLOHMANN_JSON_VERSION / 'include'
+    header_path = include_dir / 'nlohmann' / 'json.hpp'
+    if header_path.exists():
+        return str(include_dir)
+
+    header_path.parent.mkdir(parents=True, exist_ok=True)
+    last_error = None
+    for url in NLOHMANN_JSON_URLS:
+        try:
+            with urlopen(url) as response:
+                header_path.write_bytes(response.read())
+            return str(include_dir)
+        except Exception as exc:  # noqa: BLE001
+            last_error = exc
+
+    raise RuntimeError(
+        f'Unable to download nlohmann/json.hpp for {NLOHMANN_JSON_VERSION}: {last_error}'
+    )
+
+
+class WarpDBBuildExt(build_ext):
+    def build_extensions(self):
+        include_dir = ensure_nlohmann_json_header(Path(__file__).resolve().parent / '.build_deps')
+        for ext in self.extensions:
+            if include_dir not in ext.include_dirs:
+                ext.include_dirs.append(include_dir)
+        super().build_extensions()
 
 include_files = glob('include/*.hpp') + glob('include/*.h')
 data_files = ['data/test.csv', 'data/test.json', 'data/malformed.json']
@@ -29,7 +69,7 @@ setup(
     version='0.1.0',
     description='Python bindings for WarpDB',
     ext_modules=ext_modules,
-    cmdclass={'build_ext': build_ext},
+    cmdclass={'build_ext': WarpDBBuildExt},
     data_files=[('include', include_files), ('data', data_files)],
     zip_safe=False,
 )


### PR DESCRIPTION
### Motivation

- Ensure `Pybind11Extension` can always find `nlohmann/json.hpp` for Python-only builds without requiring packagers to pre-install the header, and keep the Python packaging behavior aligned with the CMake `FetchContent` pinned dependency.

### Description

- Add a pinned version constant `NLOHMANN_JSON_VERSION = 'v3.2.0'` and candidate raw URLs in `setup.py` to fetch `nlohmann/json.hpp` matching the CMake pin.
- Implement `ensure_nlohmann_json_header(base_dir)` to download and cache the single-header into `.build_deps/nlohmann_json/v3.2.0/include` when missing.
- Introduce `WarpDBBuildExt(build_ext)` which appends the fetched include directory to every extension's `include_dirs` before building, and wire it into `setup()` via `cmdclass={'build_ext': WarpDBBuildExt}`.
- Document the behavior in `README.md` so Python-only builders know the header is automatically provided during `pip install .`/packaging.

### Testing

- Ran `python -m py_compile setup.py` to validate Python syntax and it succeeded.
- Verified the pinned header URL is reachable using `urllib.request.urlopen` against the raw `nlohmann/json` file and the check returned HTTP `200`.
- Confirmed the repository diffs and packaging changes produce the expected `setup.py` modifications and `README.md` documentation (local validations completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bb08f871c8328943af8b452da5799)