### PR TITLE
Include multi_gpu_utils.cpp in pybind11 extension build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ ext_modules = [
             'src/json_loader.cpp',
             'src/expression.cpp',
             'src/jit.cpp',
+            'src/multi_gpu_utils.cpp',
             'src/optimizer.cpp',
             'src/arrow_utils.cpp',
         ],


### PR DESCRIPTION
### Motivation
- Ensure symbols used by `WarpDB::query_multi_gpu` and `WarpDB::query_multi_gpu_csv` are linked into the Python extension by compiling `src/multi_gpu_utils.cpp` with the other core sources.

### Description
- Added `src/multi_gpu_utils.cpp` to the `Pybind11Extension(..., sources=[...])` list in `setup.py` so the multi-GPU helper implementation is built into the `pywarpdb` extension.

### Testing
- Ran `python -m py_compile setup.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bb08e9bc88328869a2e1cff44c1ae)