### PR TITLE
Add executable declaration for multi_gpu_arbitrary_columns_test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,9 @@ add_executable(multi_gpu_sharding_test
 target_link_libraries(multi_gpu_sharding_test PRIVATE warpdb_lib)
 add_test(NAME multi_gpu_sharding_test COMMAND multi_gpu_sharding_test)
 
+add_executable(multi_gpu_arbitrary_columns_test
+    tests/multi_gpu_arbitrary_columns_test.cpp
+)
 target_link_libraries(multi_gpu_arbitrary_columns_test PRIVATE warpdb_lib)
 add_test(NAME multi_gpu_arbitrary_columns_test COMMAND multi_gpu_arbitrary_columns_test)
 


### PR DESCRIPTION
### Motivation
- Ensure the `multi_gpu_arbitrary_columns_test` CMake target is declared before being linked and registered as a test so its definition order matches nearby test targets.

### Description
- Inserted `add_executable(multi_gpu_arbitrary_columns_test tests/multi_gpu_arbitrary_columns_test.cpp)` immediately before the existing `target_link_libraries(multi_gpu_arbitrary_columns_test PRIVATE warpdb_lib)` and `add_test(...)` lines and left those lines unchanged.

### Testing
- Verified the file update and target ordering by inspecting `CMakeLists.txt` with `nl -ba CMakeLists.txt | sed -n '112,134p'`, confirming the sequence `add_executable` → `target_link_libraries` → `add_test` for the test block.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bb08b6ad48328a36f559489516020)