### PR TITLE
Add missing CMake target for multi_gpu_arbitrary_columns_test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,9 @@ add_executable(multi_gpu_sharding_test
 target_link_libraries(multi_gpu_sharding_test PRIVATE warpdb_lib)
 add_test(NAME multi_gpu_sharding_test COMMAND multi_gpu_sharding_test)
 
+add_executable(multi_gpu_arbitrary_columns_test
+    tests/multi_gpu_arbitrary_columns_test.cpp
+)
 target_link_libraries(multi_gpu_arbitrary_columns_test PRIVATE warpdb_lib)
 add_test(NAME multi_gpu_arbitrary_columns_test COMMAND multi_gpu_arbitrary_columns_test)
 


### PR DESCRIPTION
### Motivation
- Ensure the `multi_gpu_arbitrary_columns_test` target is defined so it can be linked and registered with CMake and run as part of the test suite.

### Description
- Add `add_executable(multi_gpu_arbitrary_columns_test tests/multi_gpu_arbitrary_columns_test.cpp)` to `CMakeLists.txt` so the existing `target_link_libraries(...)` and `add_test(...)` lines reference a valid target.

### Testing
- Ran CMake configure with `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`; configuration fails in this environment because the CUDA toolkit / `nvcc` is not available, so no full build or tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d9e6acac483288b9a7a3f46f5221a)