### PR TITLE
Fail fast when SQL JOIN is parsed but not executable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,12 @@ target_link_libraries(sql_features_test PRIVATE warpdb_lib)
 
 add_test(NAME sql_features_test COMMAND sql_features_test)
 
+add_executable(join_not_supported_test
+    tests/join_not_supported_test.cpp
+)
+target_link_libraries(join_not_supported_test PRIVATE warpdb_lib)
+add_test(NAME join_not_supported_test COMMAND join_not_supported_test)
+
 add_executable(extended_types_test
     tests/extended_types_test.cpp
 )

--- a/include/warpdb.hpp
+++ b/include/warpdb.hpp
@@ -19,8 +19,9 @@ public:
     // Example: "price * quantity WHERE price > 10"
     std::vector<float> query(const std::string &expr);
 
-    // Execute a full SQL query supporting GROUP BY and ORDER BY.
-    // Currently JOIN loads the same table for demonstration purposes.
+    // Execute a full SQL query supporting WHERE/GROUP BY/HAVING/ORDER BY,
+    // DISTINCT/LIMIT/OFFSET on a single loaded table.
+    // JOIN clauses are parsed by the SQL frontend but are not executed yet.
     std::vector<float> query_sql(const std::string &sql);
 
     // Execute a query using all available GPUs on the data loaded in this

--- a/src/warpdb.cpp
+++ b/src/warpdb.cpp
@@ -337,6 +337,12 @@ std::vector<float> WarpDB::query_sql(const std::string &sql) {
     for (const auto &c : table_.columns) cols.insert(c.name);
     validate_query_ast(ast, cols);
 
+    if (!ast.joins.empty()) {
+        throw std::runtime_error(
+            "JOIN is parsed but not executed yet. SQL execution currently "
+            "supports single-table queries only.");
+    }
+
     std::vector<int> rows = filter_rows(ast, host_table_);
 
     std::vector<float> result;

--- a/tests/join_not_supported_test.cpp
+++ b/tests/join_not_supported_test.cpp
@@ -1,0 +1,20 @@
+#include "warpdb.hpp"
+#include <cassert>
+#include <stdexcept>
+#include <string>
+
+int main() {
+    WarpDB db("data/test.csv");
+
+    bool saw_error = false;
+    try {
+        (void)db.query_sql(
+            "SELECT price FROM test JOIN test ON id == id WHERE price > 0");
+    } catch (const std::runtime_error &e) {
+        saw_error = std::string(e.what()).find("JOIN is parsed but not executed yet") !=
+                    std::string::npos;
+    }
+
+    assert(saw_error);
+    return 0;
+}


### PR DESCRIPTION
### Motivation
- The SQL frontend parsed `JOIN` clauses into the AST but the execution path never performed joins, which could silently return incorrect single-table results. 
- Make the current single-table limitation explicit and fail fast to avoid confusing behavior until a proper join execution path is implemented.

### Description
- Added a guard in `WarpDB::query_sql` that throws a `runtime_error` when `ast.joins` is non-empty with a clear explanatory message. 
- Updated the `query_sql` API comment in `include/warpdb.hpp` to document that only single-table SQL execution (`WHERE`/`GROUP BY`/`HAVING`/`ORDER BY`/`DISTINCT`/`LIMIT`/`OFFSET`) is supported and that `JOIN` is parsed but not executed. 
- Added a regression test `tests/join_not_supported_test.cpp` that asserts a `JOIN` query raises the expected error. 
- Registered the new test target in `CMakeLists.txt` so it is included in the test suite.

### Testing
- Added the automated test `join_not_supported_test` to the CMake test targets (not yet passing on this environment because it was only added). 
- Attempted to configure, build, and run `join_not_supported_test` with `cmake -S . -B build && cmake --build build --target join_not_supported_test && ctest --test-dir build -R join_not_supported_test --output-on-failure`, but the operation failed due to the environment missing the CUDA toolkit (`nvcc`), so the new test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e65b5ceb088328aede69723c01d5fc)