### PR TITLE
Refactor query APIs to return typed QueryResult (ColumnData) instead of float vectors

### DIFF
--- a/bindings/python/pywarpdb.cpp
+++ b/bindings/python/pywarpdb.cpp
@@ -4,6 +4,10 @@
 
 namespace py = pybind11;
 
+static py::object column_data_to_python(const ColumnData &data) {
+    return std::visit([](const auto &vec) -> py::object { return py::cast(vec); }, data);
+}
+
 PYBIND11_MODULE(pywarpdb, m) {
     py::enum_<DataType>(m, "DataType")
         .value("Int32", DataType::Int32)
@@ -21,13 +25,24 @@ PYBIND11_MODULE(pywarpdb, m) {
              py::arg("filepath"),
              py::arg("schema") = std::vector<DataType>(),
              py::arg("policy") = ParsePolicy::Strict)
-        .def("query", &WarpDB::query, py::arg("expr"))
-        .def("query_sql", &WarpDB::query_sql, py::arg("sql"),
+        .def("query", [](WarpDB &db, const std::string &expr) {
+                return column_data_to_python(db.query(expr).data());
+             }, py::arg("expr"))
+        .def("query_sql", [](WarpDB &db, const std::string &sql) {
+                return column_data_to_python(db.query_sql(sql).data());
+             }, py::arg("sql"),
              R"pbdoc(Execute a full SQL query supporting GROUP BY and ORDER BY.)pbdoc")
-        .def("query_multi_gpu", &WarpDB::query_multi_gpu,
+        .def("query_multi_gpu", [](WarpDB &db, const std::string &expr) {
+                return column_data_to_python(db.query_multi_gpu(expr).data());
+             },
              py::arg("expr"),
              R"pbdoc(Execute expression using all available GPUs on the current table.)pbdoc")
-        .def_static("query_multi_gpu_csv", &WarpDB::query_multi_gpu_csv,
+        .def_static("query_multi_gpu_csv", [](const std::string &csv_path,
+                                              const std::string &expr,
+                                              int rows_per_chunk) {
+                return column_data_to_python(
+                    WarpDB::query_multi_gpu_csv(csv_path, expr, rows_per_chunk).data());
+             },
                     py::arg("csv_path"), py::arg("expr"),
                     py::arg("rows_per_chunk") = 1000000,
                     R"pbdoc(Stream a CSV file in chunks across all GPUs and return results.)pbdoc")

--- a/include/warpdb.hpp
+++ b/include/warpdb.hpp
@@ -1,12 +1,53 @@
 #pragma once
 #include <string>
 #include <vector>
+#include <variant>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
 
 #include "csv_loader.hpp"
 #include "json_loader.hpp"
 #include "expression.hpp"
 #include "jit.hpp"
 #include "arrow_utils.hpp"
+
+class QueryResult {
+public:
+    QueryResult() : data_(std::vector<float>{}) {}
+    explicit QueryResult(ColumnData data) : data_(std::move(data)) {}
+
+    size_t size() const {
+        return std::visit([](const auto &v) { return v.size(); }, data_);
+    }
+
+    bool empty() const { return size() == 0; }
+
+    const ColumnData &data() const { return data_; }
+
+    template <typename T>
+    const std::vector<T> &as() const {
+        return std::get<std::vector<T>>(data_);
+    }
+
+    float operator[](size_t idx) const {
+        return std::visit(
+            [idx](const auto &v) -> float {
+                using VecT = std::decay_t<decltype(v)>;
+                using ValueT = typename VecT::value_type;
+                if constexpr (std::is_same_v<ValueT, std::string>) {
+                    throw std::runtime_error(
+                        "String results cannot be accessed via float operator[]");
+                } else {
+                    return static_cast<float>(v[idx]);
+                }
+            },
+            data_);
+    }
+
+private:
+    ColumnData data_;
+};
 
 class WarpDB {
 public:
@@ -17,23 +58,23 @@ public:
 
     // Execute an expression with optional WHERE clause.
     // Example: "price * quantity WHERE price > 10"
-    std::vector<float> query(const std::string &expr);
+    QueryResult query(const std::string &expr);
 
     // Execute a full SQL query supporting GROUP BY and ORDER BY.
     // Currently JOIN loads the same table for demonstration purposes.
-    std::vector<float> query_sql(const std::string &sql);
+    QueryResult query_sql(const std::string &sql);
 
     // Execute a query using all available GPUs on the data loaded in this
     // WarpDB instance. Falls back to single-GPU execution when only one device
     // is present.
-    std::vector<float> query_multi_gpu(const std::string &expr);
+    QueryResult query_multi_gpu(const std::string &expr);
 
     // Stream a CSV file in chunks and execute the same expression across all
     // GPUs. Useful when the dataset is larger than GPU memory. This static
     // helper does not require constructing a WarpDB instance.
-    static std::vector<float> query_multi_gpu_csv(const std::string &csv_path,
-                                                 const std::string &expr,
-                                                 int rows_per_chunk = 1000000);
+    static QueryResult query_multi_gpu_csv(const std::string &csv_path,
+                                           const std::string &expr,
+                                           int rows_per_chunk = 1000000);
 
     // Execute a query and export the results as Arrow buffers.
     // The ArrowArray and ArrowSchema must be provided by the caller.

--- a/src/warpdb.cpp
+++ b/src/warpdb.cpp
@@ -92,7 +92,7 @@ WarpDB::~WarpDB() {
     }
 }
 
-std::vector<float> WarpDB::query(const std::string &expr) {
+QueryResult WarpDB::query(const std::string &expr) {
     if (expr.empty()) {
         throw std::runtime_error("Empty query expression");
     }
@@ -147,7 +147,7 @@ std::vector<float> WarpDB::query(const std::string &expr) {
     CUDA_CHECK(cudaMemcpy(result.data(), d_output.get(),
                          sizeof(float) * table_.num_rows,
                          cudaMemcpyDeviceToHost));
-    return result;
+    return QueryResult(std::move(result));
 }
 
 
@@ -292,9 +292,10 @@ std::vector<float> execute_group_by(const QueryAST &ast,
     return result;
 }
 
-void apply_order_by(const QueryAST &ast, const HostTable &table,
-                    const std::vector<int> &rows, std::vector<float> &result) {
-    std::vector<std::pair<float,float>> keyed;
+template <typename T>
+void apply_order_by_typed(const QueryAST &ast, const HostTable &table,
+                          const std::vector<int> &rows, std::vector<T> &result) {
+    std::vector<std::pair<float, T>> keyed;
     for (size_t i = 0; i < rows.size(); ++i) {
         float key = eval_node(ast.order_by->expr.get(), table, rows[i]);
         keyed.push_back({key, result[i]});
@@ -308,7 +309,8 @@ void apply_order_by(const QueryAST &ast, const HostTable &table,
     }
 }
 
-void apply_limit_offset(const QueryAST &ast, std::vector<float> &result) {
+template <typename T>
+void apply_limit_offset_typed(const QueryAST &ast, std::vector<T> &result) {
     if (ast.offset) {
         size_t off = static_cast<size_t>(ast.offset->count);
         if (off >= result.size()) {
@@ -322,9 +324,81 @@ void apply_limit_offset(const QueryAST &ast, std::vector<float> &result) {
     }
 }
 
+template <typename T>
+void apply_distinct_typed(std::vector<T> &result) {
+    std::sort(result.begin(), result.end());
+    result.erase(std::unique(result.begin(), result.end()), result.end());
+}
+
+ColumnData select_typed_column(const HostColumn &col, const std::vector<int> &rows) {
+    switch (col.type) {
+    case DataType::Int32: {
+        const auto &src = std::get<std::vector<int32_t>>(col.data);
+        std::vector<int32_t> out;
+        out.reserve(rows.size());
+        for (int idx : rows) out.push_back(src[idx]);
+        return out;
+    }
+    case DataType::Int64: {
+        const auto &src = std::get<std::vector<int64_t>>(col.data);
+        std::vector<int64_t> out;
+        out.reserve(rows.size());
+        for (int idx : rows) out.push_back(src[idx]);
+        return out;
+    }
+    case DataType::Float32: {
+        const auto &src = std::get<std::vector<float>>(col.data);
+        std::vector<float> out;
+        out.reserve(rows.size());
+        for (int idx : rows) out.push_back(src[idx]);
+        return out;
+    }
+    case DataType::Float64: {
+        const auto &src = std::get<std::vector<double>>(col.data);
+        std::vector<double> out;
+        out.reserve(rows.size());
+        for (int idx : rows) out.push_back(src[idx]);
+        return out;
+    }
+    case DataType::String: {
+        const auto &src = std::get<std::vector<std::string>>(col.data);
+        std::vector<std::string> out;
+        out.reserve(rows.size());
+        for (int idx : rows) out.push_back(src[idx]);
+        return out;
+    }
+    }
+    return std::vector<float>{};
+}
+
+void apply_order_by(const QueryAST &ast, const HostTable &table,
+                    const std::vector<int> &rows, ColumnData &result) {
+    std::visit(
+        [&](auto &vec) {
+            apply_order_by_typed(ast, table, rows, vec);
+        },
+        result);
+}
+
+void apply_limit_offset(const QueryAST &ast, ColumnData &result) {
+    std::visit(
+        [&](auto &vec) {
+            apply_limit_offset_typed(ast, vec);
+        },
+        result);
+}
+
+void apply_distinct(ColumnData &result) {
+    std::visit(
+        [&](auto &vec) {
+            apply_distinct_typed(vec);
+        },
+        result);
+}
+
 } // namespace
 
-std::vector<float> WarpDB::query_sql(const std::string &sql) {
+QueryResult WarpDB::query_sql(const std::string &sql) {
     auto tokens = tokenize(sql);
     QueryAST ast;
     try {
@@ -339,12 +413,22 @@ std::vector<float> WarpDB::query_sql(const std::string &sql) {
 
     std::vector<int> rows = filter_rows(ast, host_table_);
 
-    std::vector<float> result;
+    ColumnData result = std::vector<float>{};
     if (ast.group_by) {
         result = execute_group_by(ast, host_table_, rows);
     } else {
-        for (int idx : rows) {
-            result.push_back(eval_node(ast.select_list[0].get(), host_table_, idx));
+        if (auto *var =
+                dynamic_cast<VariableNode *>(ast.select_list[0].get())) {
+            const HostColumn *col = host_table_.get_column(var->name);
+            if (!col) {
+                throw std::runtime_error("Unknown column in SELECT: " + var->name);
+            }
+            result = select_typed_column(*col, rows);
+        } else {
+            auto &out = std::get<std::vector<float>>(result);
+            for (int idx : rows) {
+                out.push_back(eval_node(ast.select_list[0].get(), host_table_, idx));
+            }
         }
         if (ast.order_by) {
             apply_order_by(ast, host_table_, rows, result);
@@ -352,12 +436,11 @@ std::vector<float> WarpDB::query_sql(const std::string &sql) {
     }
 
     if (ast.distinct) {
-        std::sort(result.begin(), result.end());
-        result.erase(std::unique(result.begin(), result.end()), result.end());
+        apply_distinct(result);
     }
 
     apply_limit_offset(ast, result);
-    return result;
+    return QueryResult(std::move(result));
 }
 
 
@@ -365,13 +448,14 @@ std::vector<float> WarpDB::query_sql(const std::string &sql) {
 void WarpDB::query_arrow(const std::string &expr, ArrowArray *out_array,
                          ArrowSchema *out_schema, bool use_shared_memory,
                          const char* shm_name) {
-    auto result = query(expr);
+    QueryResult qr = query(expr);
+    const auto &result = qr.as<float>();
     export_to_arrow(result.data(), static_cast<int64_t>(result.size()),
                     use_shared_memory, out_array, out_schema, shm_name);
 
 }
 
-std::vector<float> WarpDB::query_multi_gpu(const std::string &expr) {
+QueryResult WarpDB::query_multi_gpu(const std::string &expr) {
     if (host_table_.num_rows() == 0) {
         throw std::runtime_error("Host table not available for multi-GPU query");
     }
@@ -407,12 +491,12 @@ std::vector<float> WarpDB::query_multi_gpu(const std::string &expr) {
         condition_cuda = cond_ast->to_cuda_expr();
     }
 
-    return run_multi_gpu_jit_host(host_table_, expr_cuda, condition_cuda);
+    return QueryResult(run_multi_gpu_jit_host(host_table_, expr_cuda, condition_cuda));
 }
 
-std::vector<float> WarpDB::query_multi_gpu_csv(const std::string &csv_path,
-                                               const std::string &expr,
-                                               int rows_per_chunk) {
+QueryResult WarpDB::query_multi_gpu_csv(const std::string &csv_path,
+                                        const std::string &expr,
+                                        int rows_per_chunk) {
     std::string upper = expr;
     for (auto &c : upper) c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
 
@@ -472,5 +556,5 @@ std::vector<float> WarpDB::query_multi_gpu_csv(const std::string &csv_path,
         all_results.insert(all_results.end(), part.begin(), part.end());
     }
 
-    return all_results;
+    return QueryResult(std::move(all_results));
 }


### PR DESCRIPTION
### Motivation
- The public query APIs were hard-coded to `std::vector<float>` which loses native column types and prevents returning heterogeneous result columns.
- The change aims to refactor the result pipeline so SQL and Python callers can receive typed column vectors without a rewrite of the execution/JIT numeric paths.

### Description
- Introduced a `QueryResult` wrapper that holds `ColumnData` (the existing `std::variant` of typed column vectors) and exposes `size()`, `empty()`, `as<T>()`, and a numeric `operator[]` for numeric types.
- Changed `WarpDB` APIs signatures from `std::vector<float>` to `QueryResult` for `query`, `query_sql`, `query_multi_gpu`, and `query_multi_gpu_csv` and adapted return paths accordingly.
- Refactored SQL result handling to preserve native column types for direct column projection (`SELECT <column>`) and added typed helpers (`apply_order_by_typed`, `apply_limit_offset_typed`, `apply_distinct_typed`, `select_typed_column`) plus `std::visit`-based dispatch to operate on any `ColumnData` variant.
- Updated Python bindings so query methods convert the returned `ColumnData` into the corresponding Python lists via `column_data_to_python` instead of assuming float-only outputs, and kept `query_arrow` exporting float32 as before.

### Testing
- Ran a CMake configure step (`cmake -S . -B build`) to validate build graph which failed because the environment lacks the CUDA toolkit (`nvcc`), so a full build/test run could not be performed (failure).
- No automated unit or integration tests were executed in this environment due to the missing CUDA toolchain (none succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e65b70d4808328a83d810f2b24bcae)