### PR TITLE
Add join planning primitives with NDV-based cardinality estimates

### DIFF
--- a/include/optimizer.hpp
+++ b/include/optimizer.hpp
@@ -1,6 +1,9 @@
 #pragma once
 #include <string>
 #include <memory>
+#include <optional>
+#include <unordered_map>
+#include <vector>
 #include "csv_loader.hpp"
 #include "expression.hpp"
 
@@ -18,3 +21,39 @@ bool compute_table_stats(const Table &table, TableStats &stats);
 // `always_true` or `always_false` will be set to true.
 void analyze_condition(const ASTNode *node, const TableStats &stats,
                        bool &always_true, bool &always_false);
+
+struct RelationStats {
+    std::string relation;
+    double row_count = 0.0;
+    std::unordered_map<std::string, double> distinct_counts;
+};
+
+struct JoinPredicate {
+    std::string left_relation;
+    std::string left_column;
+    std::string right_relation;
+    std::string right_column;
+};
+
+struct JoinPlanStep {
+    std::string relation;
+    double estimated_rows = 0.0;
+    std::optional<JoinPredicate> predicate;
+};
+
+struct JoinPlan {
+    std::vector<JoinPlanStep> steps;
+    double estimated_total_cost = 0.0;
+};
+
+// Extract `a.x = b.y` predicates from JOIN ... ON clauses.
+std::vector<JoinPredicate> extract_equi_join_predicates(const QueryAST &ast);
+
+// Estimate cardinality for an equality join between two inputs.
+double estimate_equi_join_rows(double left_rows, double right_rows,
+                               double left_distinct, double right_distinct);
+
+// Build a greedy left-deep join plan using row count and NDV stats.
+JoinPlan build_greedy_join_plan(
+    const QueryAST &ast,
+    const std::unordered_map<std::string, RelationStats> &stats_by_relation);

--- a/src/optimizer.cpp
+++ b/src/optimizer.cpp
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <exception>
+#include <unordered_set>
 
 namespace {
 
@@ -33,6 +34,30 @@ bool copy_device_column(const ColumnDesc &col, std::vector<T> &out) {
                           sizeof(T) * col.length,
                           cudaMemcpyDeviceToHost));
     return true;
+}
+
+} // namespace
+
+namespace {
+
+struct QualifiedColumn {
+    std::string relation;
+    std::string column;
+};
+
+std::optional<QualifiedColumn> parse_qualified_column(const ASTNode *node) {
+    auto *var = dynamic_cast<const VariableNode *>(node);
+    if (!var) {
+        return std::nullopt;
+    }
+
+    const std::string &name = var->name;
+    const auto dot = name.find('.');
+    if (dot == std::string::npos || dot == 0 || dot + 1 >= name.size()) {
+        return std::nullopt;
+    }
+
+    return QualifiedColumn{name.substr(0, dot), name.substr(dot + 1)};
 }
 
 } // namespace
@@ -309,4 +334,166 @@ void execute_query_optimized(const std::string &expr_part,
         std::cout << "Result[" << i << "] = " << h_out[i] << "\n";
     }
 
+}
+
+std::vector<JoinPredicate> extract_equi_join_predicates(const QueryAST &ast) {
+    std::vector<JoinPredicate> predicates;
+    predicates.reserve(ast.joins.size());
+
+    for (const auto &join : ast.joins) {
+        auto *cmp = dynamic_cast<const BinaryOpNode *>(join.condition.get());
+        if (!cmp || (cmp->op != "=" && cmp->op != "==")) {
+            continue;
+        }
+
+        auto left = parse_qualified_column(cmp->left.get());
+        auto right = parse_qualified_column(cmp->right.get());
+        if (!left || !right || left->relation == right->relation) {
+            continue;
+        }
+
+        predicates.push_back(
+            JoinPredicate{left->relation, left->column,
+                          right->relation, right->column});
+    }
+
+    return predicates;
+}
+
+double estimate_equi_join_rows(double left_rows, double right_rows,
+                               double left_distinct, double right_distinct) {
+    const double safe_left = std::max(left_rows, 1.0);
+    const double safe_right = std::max(right_rows, 1.0);
+    const double safe_left_ndv = std::max(left_distinct, 1.0);
+    const double safe_right_ndv = std::max(right_distinct, 1.0);
+    const double denom = std::max(safe_left_ndv, safe_right_ndv);
+    return std::max(1.0, (safe_left * safe_right) / denom);
+}
+
+JoinPlan build_greedy_join_plan(
+    const QueryAST &ast,
+    const std::unordered_map<std::string, RelationStats> &stats_by_relation) {
+    JoinPlan plan;
+
+    std::unordered_set<std::string> relations;
+    if (!ast.from_table.empty()) {
+        relations.insert(ast.from_table);
+    }
+    for (const auto &join : ast.joins) {
+        relations.insert(join.table);
+    }
+    if (relations.empty()) {
+        return plan;
+    }
+
+    auto predicates = extract_equi_join_predicates(ast);
+
+    auto relation_rows = [&](const std::string &relation) {
+        const auto it = stats_by_relation.find(relation);
+        if (it == stats_by_relation.end()) {
+            return 1.0;
+        }
+        return std::max(it->second.row_count, 1.0);
+    };
+
+    auto column_ndv = [&](const std::string &relation,
+                          const std::string &column) {
+        const auto rel_it = stats_by_relation.find(relation);
+        if (rel_it == stats_by_relation.end()) {
+            return relation_rows(relation);
+        }
+        const auto ndv_it = rel_it->second.distinct_counts.find(column);
+        if (ndv_it == rel_it->second.distinct_counts.end()) {
+            return relation_rows(relation);
+        }
+        return std::max(ndv_it->second, 1.0);
+    };
+
+    std::unordered_set<std::string> joined;
+    double current_rows = 0.0;
+
+    auto seed_it = std::min_element(
+        relations.begin(), relations.end(),
+        [&](const std::string &a, const std::string &b) {
+            return relation_rows(a) < relation_rows(b);
+        });
+
+    const std::string seed = *seed_it;
+    joined.insert(seed);
+    current_rows = relation_rows(seed);
+    plan.steps.push_back(JoinPlanStep{seed, current_rows, std::nullopt});
+
+    while (joined.size() < relations.size()) {
+        double best_rows = std::numeric_limits<double>::max();
+        std::string best_relation;
+        std::optional<JoinPredicate> best_predicate;
+
+        for (const auto &candidate : relations) {
+            if (joined.count(candidate)) {
+                continue;
+            }
+
+            double candidate_rows = relation_rows(candidate);
+            bool connected = false;
+            std::optional<JoinPredicate> candidate_predicate;
+
+            for (const auto &pred : predicates) {
+                const bool left_is_candidate = pred.left_relation == candidate;
+                const bool right_is_candidate = pred.right_relation == candidate;
+
+                if (!left_is_candidate && !right_is_candidate) {
+                    continue;
+                }
+
+                const std::string other = left_is_candidate
+                                              ? pred.right_relation
+                                              : pred.left_relation;
+                if (!joined.count(other)) {
+                    continue;
+                }
+
+                connected = true;
+                const double candidate_ndv = left_is_candidate
+                                                 ? column_ndv(candidate,
+                                                              pred.left_column)
+                                                 : column_ndv(candidate,
+                                                              pred.right_column);
+                const double other_ndv = left_is_candidate
+                                             ? column_ndv(other,
+                                                          pred.right_column)
+                                             : column_ndv(other,
+                                                          pred.left_column);
+                const double est_rows = estimate_equi_join_rows(
+                    current_rows, relation_rows(candidate), other_ndv,
+                    candidate_ndv);
+                if (est_rows < candidate_rows) {
+                    candidate_rows = est_rows;
+                    candidate_predicate = pred;
+                }
+            }
+
+            if (!connected) {
+                candidate_rows = current_rows * relation_rows(candidate);
+                candidate_predicate = std::nullopt;
+            }
+
+            if (candidate_rows < best_rows) {
+                best_rows = candidate_rows;
+                best_relation = candidate;
+                best_predicate = candidate_predicate;
+            }
+        }
+
+        if (best_relation.empty()) {
+            break;
+        }
+
+        joined.insert(best_relation);
+        current_rows = std::max(best_rows, 1.0);
+        plan.steps.push_back(
+            JoinPlanStep{best_relation, current_rows, best_predicate});
+        plan.estimated_total_cost += current_rows;
+    }
+
+    return plan;
 }

--- a/tests/optimizer_test.cpp
+++ b/tests/optimizer_test.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <vector>
 #include <utility>
+#include <unordered_map>
 #include <cuda_runtime.h>
 #include "cuda_utils.hpp"
 
@@ -66,10 +67,47 @@ static void test_real_stats_prevent_elimination() {
     assert(!always_false);
 }
 
+static void test_extract_equi_join_predicates() {
+    auto tokens = tokenize(
+        "SELECT a.v FROM a JOIN b ON a.id = b.a_id JOIN c ON b.id = c.b_id");
+    QueryAST ast = parse_query(tokens);
+    auto predicates = extract_equi_join_predicates(ast);
+    assert(predicates.size() == 2);
+    assert(predicates[0].left_relation == "a");
+    assert(predicates[0].left_column == "id");
+    assert(predicates[0].right_relation == "b");
+    assert(predicates[0].right_column == "a_id");
+}
+
+static void test_build_greedy_join_plan_prefers_low_ndv_join() {
+    auto tokens = tokenize(
+        "SELECT a.v FROM a JOIN b ON a.id = b.a_id JOIN c ON b.id = c.b_id");
+    QueryAST ast = parse_query(tokens);
+
+    std::unordered_map<std::string, RelationStats> stats;
+    stats["a"] = RelationStats{"a", 100000.0, {{"id", 100000.0}}};
+    stats["b"] = RelationStats{"b", 1000.0, {{"a_id", 1000.0}, {"id", 1000.0}}};
+    stats["c"] = RelationStats{"c", 500000.0, {{"b_id", 1000.0}}};
+
+    JoinPlan plan = build_greedy_join_plan(ast, stats);
+    assert(plan.steps.size() == 3);
+    assert(plan.steps[0].relation == "b");
+    assert(plan.steps[1].relation == "a");
+    assert(plan.steps[2].relation == "c");
+}
+
+static void test_estimate_equi_join_rows_uses_max_ndv() {
+    const double rows = estimate_equi_join_rows(1000.0, 500.0, 1000.0, 50.0);
+    assert(rows == 500.0);
+}
+
 int main() {
     test_missing_stats_skip_elimination();
     test_analyze_condition_always_false();
     test_real_stats_prevent_elimination();
+    test_extract_equi_join_predicates();
+    test_build_greedy_join_plan_prefers_low_ndv_join();
+    test_estimate_equi_join_rows_uses_max_ndv();
     std::cout << "Optimizer tests passed\n";
     return 0;
 }


### PR DESCRIPTION
### Motivation
- The optimizer only supported simple filter simplification and lacked any join-planning logic, which makes multi-table joins suboptimal. 
- Introduce a minimal cardinality/cost framework so the optimizer can pick a better left-deep join order for common equi-join cases.

### Description
- Add planner-facing types and APIs in `include/optimizer.hpp`: `RelationStats`, `JoinPredicate`, `JoinPlanStep`, `JoinPlan`, and declarations for `extract_equi_join_predicates`, `estimate_equi_join_rows`, and `build_greedy_join_plan`.
- Implement qualified-column parsing, equi-join predicate extraction, NDV-based equi-join cardinality estimation (`estimate_equi_join_rows`), and a greedy left-deep join-order builder (`build_greedy_join_plan`) in `src/optimizer.cpp`.
- Extend the optimizer tests in `tests/optimizer_test.cpp` with unit cases for predicate extraction, NDV-based cardinality math, and a 3-table greedy join-order scenario.

### Testing
- Added unit tests under `tests/optimizer_test.cpp` exercising `extract_equi_join_predicates`, `estimate_equi_join_rows`, and `build_greedy_join_plan` (tests were added but not executed due to build environment constraints).
- Attempted to configure and build the `optimizer_test` target with `cmake -S . -B build -DWARPDB_BUILD_PYTHON=OFF && cmake --build build --target optimizer_test -j2`, which failed in this environment because the CUDA toolkit / `nvcc` was not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e65b77c27c8328864bb4e83b78aa6b)