### PR TITLE
Clean up CSV parsing lambda artifact and remove duplicate demo kernel calls

### DIFF
--- a/src/csv_loader.cpp
+++ b/src/csv_loader.cpp
@@ -167,8 +167,22 @@ HostTable load_csv_to_host(const std::string &filepath,
   std::vector<std::vector<std::string>> buffered_rows;
   if (inferred_schema) {
     std::string line;
+    int row = 0;
     while (std::getline(file, line)) {
       if (line.empty()) continue;
+      ++row;
+      const size_t delimiter_count =
+          static_cast<size_t>(std::count(line.begin(), line.end(), ','));
+      const size_t field_count = delimiter_count + 1;
+      if (field_count != names.size()) {
+        std::cerr << "Row " << row << " has " << field_count
+                  << " fields but " << names.size() << " were expected"
+                  << std::endl;
+        if (policy == ParsePolicy::Strict) {
+          throw std::runtime_error("Incorrect number of fields in row");
+        }
+        continue;
+      }
       std::stringstream ss(line);
       std::string value;
       std::vector<std::string> parsed(names.size());
@@ -214,26 +228,6 @@ HostTable load_csv_to_host(const std::string &filepath,
   }
 
   auto append_row = [&](const std::vector<std::string> &values, int row) {
-  std::string line;
-  int row = 0;
-  while (std::getline(file, line)) {
-    if (line.empty())
-      continue;
-    ++row;
-    const size_t delimiter_count =
-        static_cast<size_t>(std::count(line.begin(), line.end(), ','));
-    const size_t field_count = delimiter_count + 1;
-    if (field_count != names.size()) {
-      std::cerr << "Row " << row << " has " << field_count
-                << " fields but " << names.size() << " were expected"
-                << std::endl;
-      if (policy == ParsePolicy::Strict) {
-        throw std::runtime_error("Incorrect number of fields in row");
-      }
-      continue;
-    }
-    std::stringstream ss(line);
-    std::string value;
     for (size_t i = 0; i < names.size(); ++i) {
       const std::string &value = values[i];
       HostColumn &col = host.columns[i];
@@ -333,6 +327,18 @@ HostTable load_csv_to_host(const std::string &filepath,
       if (line.empty())
         continue;
       ++row;
+      const size_t delimiter_count =
+          static_cast<size_t>(std::count(line.begin(), line.end(), ','));
+      const size_t field_count = delimiter_count + 1;
+      if (field_count != names.size()) {
+        std::cerr << "Row " << row << " has " << field_count
+                  << " fields but " << names.size() << " were expected"
+                  << std::endl;
+        if (policy == ParsePolicy::Strict) {
+          throw std::runtime_error("Incorrect number of fields in row");
+        }
+        continue;
+      }
       std::stringstream ss(line);
       std::string value;
       std::vector<std::string> parsed(names.size());

--- a/src/main.cu
+++ b/src/main.cu
@@ -219,16 +219,6 @@ int main(int argc, char **argv) {
                                        table.num_rows, threshold);
   CUDA_CHECK(cudaGetLastError());
 
-  print_first_few<<<1, 4>>>(d_price, d_quantity, table.num_rows);
-  CUDA_CHECK(cudaGetLastError());
-  CUDA_CHECK(cudaDeviceSynchronize());
-
-  filter_price_gt<<<blocks, threads>>>(d_price, d_quantity,
-                                       d_price_filtered.get(),
-                                       d_quantity_filtered.get(), d_count.get(),
-                                       table.num_rows, threshold);
-  CUDA_CHECK(cudaGetLastError());
-
   CUDA_CHECK(cudaDeviceSynchronize());
 
   CUDA_CHECK(cudaMemcpy(&h_count, d_count.get(), sizeof(int),


### PR DESCRIPTION
### Motivation
- Remove a merge-artifact / WIP control-flow in CSV parsing that caused a nested file-read loop inside the `append_row` lambda and would confuse reviewers. 
- Make CSV parsing consistently validate field counts so `ParsePolicy::Strict`/`Permissive` behavior is applied predictably. 
- Eliminate duplicated demo kernel launches in the `main.cu` example to avoid redundant work and noisy output.

### Description
- Restored the `append_row` lambda in `src/csv_loader.cpp` to only append/parsing logic using the passed `values` and `row` parameters, removing the erroneous nested `while (std::getline(file, line))` merge artifact. 
- Added explicit CSV field-count validation (`delimiter_count + 1`) and strict/permissive handling in both the schema-inference path and the direct-parse path in `src/csv_loader.cpp`. 
- Removed the duplicated `print_first_few` and `filter_price_gt` launch sequence in `src/main.cu`, leaving a single intended execution path. 
- Changes touch `src/csv_loader.cpp` and `src/main.cu` and are aimed at code hygiene and reviewer feedback without changing public APIs.

### Testing
- Attempted to build with `cmake -S . -B build && cmake --build build -j2`, which failed in this environment because the CUDA toolkit / `nvcc` was not found. 
- No automated unit tests were run in this environment due to the missing CUDA toolchain.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e65b9c3a38832883f27e080f006f64)