### PR TITLE
Support scientific/exponent numeric literals in tokenizer and add tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,13 @@ add_executable(parsing_error_tests
 
 add_test(NAME parsing_error_tests COMMAND parsing_error_tests)
 
+add_executable(tokenizer_tests
+    tests/tokenizer_tests.cpp
+    src/expression.cpp
+)
+
+add_test(NAME tokenizer_tests COMMAND tokenizer_tests)
+
 
 add_executable(sql_features_test
     tests/sql_features_test.cpp

--- a/src/expression.cpp
+++ b/src/expression.cpp
@@ -72,14 +72,54 @@ std::vector<Token> tokenize(const std::string &input) {
       int start_col = column;
       int start_line = line;
       std::string num;
-      bool has_dot = false;
+
       while (i < input.size() &&
-             (std::isdigit(static_cast<unsigned char>(input[i])) ||
-              (!has_dot && input[i] == '.'))) {
-        if (input[i] == '.') has_dot = true;
+             std::isdigit(static_cast<unsigned char>(input[i]))) {
         num += input[i];
         advance_char(input[i]);
         i++;
+      }
+
+      if (i < input.size() && input[i] == '.') {
+        num += input[i];
+        advance_char(input[i]);
+        i++;
+
+        while (i < input.size() &&
+               std::isdigit(static_cast<unsigned char>(input[i]))) {
+          num += input[i];
+          advance_char(input[i]);
+          i++;
+        }
+      }
+
+      if (i < input.size() && (input[i] == 'e' || input[i] == 'E')) {
+        int exp_line = line;
+        int exp_col = column;
+        num += input[i];
+        advance_char(input[i]);
+        i++;
+
+        if (i < input.size() && (input[i] == '+' || input[i] == '-')) {
+          num += input[i];
+          advance_char(input[i]);
+          i++;
+        }
+
+        if (i >= input.size() ||
+            !std::isdigit(static_cast<unsigned char>(input[i]))) {
+          std::string msg =
+              "Malformed exponent in numeric literal at line " +
+              std::to_string(exp_line) + " column " + std::to_string(exp_col);
+          throw std::runtime_error(msg);
+        }
+
+        while (i < input.size() &&
+               std::isdigit(static_cast<unsigned char>(input[i]))) {
+          num += input[i];
+          advance_char(input[i]);
+          i++;
+        }
       }
       tokens.push_back({TokenType::Number, num, start_line, start_col});
     } else if (input[i] == '>' || input[i] == '<' || input[i] == '=' ||

--- a/tests/parsing_error_tests.cpp
+++ b/tests/parsing_error_tests.cpp
@@ -44,10 +44,40 @@ void test_unbalanced_parentheses() {
     assert(threw && "Expected expression parse failure");
 }
 
+void test_malformed_exponent_missing_digits() {
+    bool threw = false;
+    try {
+        auto tokens = tokenize("1e");
+        (void)tokens;
+    } catch (const std::runtime_error &e) {
+        threw = true;
+        std::string msg = e.what();
+        assert(msg.find("Malformed exponent in numeric literal") != std::string::npos);
+        assert(msg.find("line 1 column 2") != std::string::npos);
+    }
+    assert(threw && "Expected malformed exponent error");
+}
+
+void test_malformed_exponent_missing_digits_after_sign() {
+    bool threw = false;
+    try {
+        auto tokens = tokenize("1e+");
+        (void)tokens;
+    } catch (const std::runtime_error &e) {
+        threw = true;
+        std::string msg = e.what();
+        assert(msg.find("Malformed exponent in numeric literal") != std::string::npos);
+        assert(msg.find("line 1 column 2") != std::string::npos);
+    }
+    assert(threw && "Expected malformed exponent error with explicit sign");
+}
+
 int main() {
     test_invalid_character();
     test_unexpected_token_query();
     test_unbalanced_parentheses();
+    test_malformed_exponent_missing_digits();
+    test_malformed_exponent_missing_digits_after_sign();
     std::cout << "All regression tests passed\n";
     return 0;
 }

--- a/tests/tokenizer_tests.cpp
+++ b/tests/tokenizer_tests.cpp
@@ -41,10 +41,28 @@ void test_logical_keywords() {
     assert(found_and && !found_or);
 }
 
+void test_exponent_number_tokenize() {
+    auto tokens = tokenize("1e3 .5e+2 2.0E-4");
+    assert(tokens.size() == 4);
+    assert(tokens[0].type == TokenType::Number && tokens[0].value == "1e3");
+    assert(tokens[1].type == TokenType::Number && tokens[1].value == ".5e+2");
+    assert(tokens[2].type == TokenType::Number && tokens[2].value == "2.0E-4");
+    assert(tokens[3].type == TokenType::End);
+}
+
+void test_exponent_to_cuda_suffix() {
+    auto tokens = tokenize("1e3 + .5e+2 + 2E-1");
+    auto ast = parse_expression(tokens);
+    std::string code = ast->to_cuda_expr();
+    assert(code == "((1e3f + .5e+2f) + 2E-1f)");
+}
+
 int main() {
     test_basic_tokenize();
     test_parentheses_tokenize();
     test_logical_keywords();
+    test_exponent_number_tokenize();
+    test_exponent_to_cuda_suffix();
     std::cout << "All tokenizer tests passed\n";
     return 0;
 }


### PR DESCRIPTION
### Motivation
- Allow numeric literals in scientific/exponent form (`digits[.digits][e|E][+|-]digits`, `.digits[e|E][+|-]digits`, `digits[e|E][+|-]digits`) so expressions like `1e3`, `.5e+2`, and `2.0E-4` are tokenized and handled correctly.
- Preserve existing behavior for plain integers and decimal literals while ensuring CUDA codegen receives proper float literals.
- Surface clear errors for malformed exponent forms (e.g., `1e`, `1e+`) including exact `line`/`column` to help diagnosis.

### Description
- Extended the numeric scanning logic in `tokenize` (`src/expression.cpp`) to parse optional fractional and exponent segments and to accept an optional `+`/`-` after the exponent marker `e`/`E`.
- Added a runtime check that throws a `std::runtime_error` with a message containing the `line` and `column` when an exponent is malformed (missing digits after `e` or after a sign).
- Added positive tests for exponent tokenization and CUDA literal suffix generation in `tests/tokenizer_tests.cpp` and negative tests for malformed exponents in `tests/parsing_error_tests.cpp`.
- Registered the new `tokenizer_tests` target in `CMakeLists.txt` so the test is buildable and runnable; `ConstantNode::to_cuda_expr` behavior was left intact and verified by tests.

### Testing
- Built and ran tokenizer tests with `g++ -std=c++17 -Iinclude tests/tokenizer_tests.cpp src/expression.cpp -o /tmp/tokenizer_tests && /tmp/tokenizer_tests`, which succeeded.
- Built and ran parsing/negative tests with `g++ -std=c++17 -Iinclude tests/parsing_error_tests.cpp src/expression.cpp -o /tmp/parsing_error_tests && /tmp/parsing_error_tests`, which succeeded.
- Built and ran existing parser/CUDA-expression test with `g++ -std=c++17 -Iinclude tests/test_expression.cpp src/expression.cpp -o /tmp/test_expression && /tmp/test_expression`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e66a6fb70483289dda112358105efa)