### PR TITLE
Refine ORDER BY parser boundaries around trailing clauses

### DIFF
--- a/src/expression.cpp
+++ b/src/expression.cpp
@@ -456,8 +456,13 @@ QueryAST Parser::parse_query() {
     size_t start = current;
     while (current < end &&
            !(toks[current].type == TokenType::Keyword &&
-             (toks[current].value == "ASC" ||
-              toks[current].value == "DESC")))
+             (toks[current].value == "ASC" || toks[current].value == "DESC" ||
+              toks[current].value == "LIMIT" ||
+              toks[current].value == "OFFSET" ||
+              toks[current].value == "HAVING" ||
+              toks[current].value == "GROUP" ||
+              toks[current].value == "WHERE" ||
+              toks[current].value == "JOIN")))
       current++;
     std::vector<Token> ord(toks.begin() + start, toks.begin() + current);
     ord.push_back({TokenType::End, "", 0, 0});

--- a/tests/query_parser_test.cpp
+++ b/tests/query_parser_test.cpp
@@ -12,6 +12,31 @@ int main() {
     assert(ast.group_by.has_value());
     assert(ast.order_by.has_value());
     assert(ast.limit.has_value());
+
+    std::string order_limit_q = "SELECT price FROM sales ORDER BY price LIMIT 5";
+    auto order_limit_tokens = tokenize(order_limit_q);
+    QueryAST order_limit_ast = parse_query(order_limit_tokens);
+    assert(order_limit_ast.order_by.has_value());
+    assert(order_limit_ast.order_by->ascending);
+    assert(order_limit_ast.limit.has_value());
+    assert(order_limit_ast.limit->count == 5);
+
+    std::string order_offset_q = "SELECT price FROM sales ORDER BY price OFFSET 10";
+    auto order_offset_tokens = tokenize(order_offset_q);
+    QueryAST order_offset_ast = parse_query(order_offset_tokens);
+    assert(order_offset_ast.order_by.has_value());
+    assert(order_offset_ast.order_by->ascending);
+    assert(order_offset_ast.offset.has_value());
+    assert(order_offset_ast.offset->count == 10);
+
+    std::string order_only_q = "SELECT price FROM sales ORDER BY price";
+    auto order_only_tokens = tokenize(order_only_q);
+    QueryAST order_only_ast = parse_query(order_only_tokens);
+    assert(order_only_ast.order_by.has_value());
+    assert(order_only_ast.order_by->ascending);
+    assert(!order_only_ast.limit.has_value());
+    assert(!order_only_ast.offset.has_value());
+
     std::cout << "Query parse test passed\n";
     return 0;
 }


### PR DESCRIPTION
### Motivation
- Prevent `ORDER BY` expression parsing from consuming tokens that belong to trailing clauses such as `LIMIT`/`OFFSET`/`HAVING`/`GROUP`/`WHERE`/`JOIN` so expressions are parsed correctly.
- Preserve the existing optional `ASC|DESC` direction handling that may follow the expression.
- Add coverage for common `ORDER BY` usages that previously could be ambiguous to ensure correct behavior.

### Description
- Updated `Parser::parse_query` in `src/expression.cpp` to make the `ORDER BY` expression scan stop on clause boundaries (`LIMIT`, `OFFSET`, `HAVING`, `GROUP`, `WHERE`, `JOIN`) in addition to `ASC`/`DESC` and end-of-query. (`src/expression.cpp` ORDER BY loop condition adjusted.)
- Left the `ASC|DESC` handling intact after parsing the `ORDER BY` expression so explicit directions are still recognized.
- Added tests to `tests/query_parser_test.cpp` to assert parsing for `ORDER BY price LIMIT 5`, `ORDER BY price OFFSET 10`, and `ORDER BY price` (no trailing clause or direction), while retaining the existing `ORDER BY ... DESC LIMIT ...` case.

### Testing
- Built and ran the parser test directly with `g++ -std=c++17 -Iinclude tests/query_parser_test.cpp src/expression.cpp -o /tmp/query_parser_test && /tmp/query_parser_test`.
- Result: `Query parse test passed`, confirming the new cases and the existing `ORDER BY ... DESC LIMIT ...` behavior parse correctly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e66a706e0883289a01123d4da2d217)