### PR TITLE
Tokenize and split WHERE clause at token boundary (no string substring)

### DIFF
--- a/include/expression.hpp
+++ b/include/expression.hpp
@@ -15,6 +15,14 @@ struct Token {
 
 std::vector<Token> tokenize(const std::string &input);
 
+struct WhereClauseSplit {
+  std::vector<Token> expression_tokens;
+  std::vector<Token> where_tokens;
+  bool has_where = false;
+};
+
+WhereClauseSplit split_where_clause_tokens(const std::vector<Token> &tokens);
+
 enum class ASTNodeType { Constant, Variable, BinaryOp, FunctionCall, Aggregation };
 
 

--- a/include/optimizer.hpp
+++ b/include/optimizer.hpp
@@ -7,8 +7,8 @@
 #include "csv_loader.hpp"
 #include "expression.hpp"
 
-void execute_query_optimized(const std::string &expr_part,
-                             const std::string &where_part, Table &table);
+void execute_query_optimized(const std::vector<Token> &expr_tokens,
+                             const std::vector<Token> &where_tokens, Table &table);
 
 // Populate table statistics by copying numeric columns from device to host
 // memory. Returns true when statistics for at least one numeric column were

--- a/src/expression.cpp
+++ b/src/expression.cpp
@@ -119,6 +119,45 @@ std::vector<Token> tokenize(const std::string &input) {
   return tokens;
 }
 
+WhereClauseSplit split_where_clause_tokens(const std::vector<Token> &tokens) {
+  WhereClauseSplit split;
+  size_t end_idx = tokens.size();
+  for (size_t i = 0; i < tokens.size(); ++i) {
+    if (tokens[i].type == TokenType::End) {
+      end_idx = i;
+      break;
+    }
+  }
+
+  size_t where_idx = end_idx;
+  for (size_t i = 0; i < end_idx; ++i) {
+    if (tokens[i].type == TokenType::Keyword && tokens[i].value == "WHERE") {
+      where_idx = i;
+      split.has_where = true;
+      break;
+    }
+  }
+
+  split.expression_tokens.insert(split.expression_tokens.end(), tokens.begin(),
+                                 tokens.begin() + where_idx);
+  if (split.has_where) {
+    split.where_tokens.insert(split.where_tokens.end(), tokens.begin() + where_idx + 1,
+                              tokens.begin() + end_idx);
+  }
+
+  Token end_token{TokenType::End, "", 1, 1};
+  if (end_idx < tokens.size()) {
+    end_token = tokens[end_idx];
+  }
+
+  split.expression_tokens.push_back(end_token);
+  if (split.has_where) {
+    split.where_tokens.push_back(end_token);
+  }
+
+  return split;
+}
+
 namespace {
 
 class Parser {

--- a/src/main.cu
+++ b/src/main.cu
@@ -105,21 +105,15 @@ int main(int argc, char **argv) {
     std::string csv_path = "data/test.csv";
     if (argc >= 3)
       csv_path = argv[2];
-    std::string upper_query = user_query;
-    for (auto &c : upper_query)
-      c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
+  auto tokens = tokenize(user_query);
+  auto split = split_where_clause_tokens(tokens);
 
-  std::string expr_part = user_query;
-  std::string where_part;
-  auto where_pos = upper_query.find("WHERE");
-  if (where_pos != std::string::npos) {
-    expr_part = user_query.substr(0, where_pos);
-    where_part = user_query.substr(where_pos + 5); // skip "WHERE"
+  auto expr_ast_preview = parse_expression(split.expression_tokens);
+  std::cout << "Expr (CUDA): " << expr_ast_preview->to_cuda_expr() << "\n";
+  if (split.has_where) {
+    auto where_ast_preview = parse_expression(split.where_tokens);
+    std::cout << "Where (CUDA): " << where_ast_preview->to_cuda_expr() << "\n";
   }
-
-  std::cout << "Expr: " << expr_part << "\n";
-  if (!where_part.empty())
-    std::cout << "Where: " << where_part << "\n";
 
   Table table = load_csv_to_gpu(csv_path);
   std::cout << "Loaded " << table.num_rows << " rows.\n";
@@ -185,17 +179,15 @@ int main(int argc, char **argv) {
   }
 
   std::cout << "\n[ Optimizer Demo ]\n";
-  execute_query_optimized(expr_part, where_part, table);
+  execute_query_optimized(split.expression_tokens, split.where_tokens, table);
 
 
   std::string condition_cuda;
-  if (!where_part.empty()) {
-    auto cond_tokens = tokenize(where_part);
-    auto cond_ast = parse_expression(cond_tokens);
+  if (split.has_where) {
+    auto cond_ast = parse_expression(split.where_tokens);
     condition_cuda = cond_ast->to_cuda_expr();
   }
 
-  auto tokens = tokenize(user_query);
   std::cout << "\nTokenized Expression:\n";
   for (auto &tok : tokens) {
     std::cout << "  ["
@@ -207,7 +199,7 @@ int main(int argc, char **argv) {
   }
 
   // parse
-  auto ast = parse_expression(tokens);
+  auto ast = parse_expression(split.expression_tokens);
   std::cout << "\nParsed Expression (CUDA):\n";
 
   std::string expr_cuda = ast->to_cuda_expr();

--- a/src/optimizer.cpp
+++ b/src/optimizer.cpp
@@ -290,15 +290,13 @@ void analyze_condition(const ASTNode *node, const TableStats &stats,
     }
 }
 
-void execute_query_optimized(const std::string &expr_part,
-                             const std::string &where_part, Table &table) {
-    auto expr_tokens = tokenize(expr_part);
+void execute_query_optimized(const std::vector<Token> &expr_tokens,
+                             const std::vector<Token> &where_tokens, Table &table) {
     auto expr_ast = parse_expression(expr_tokens);
 
     std::unique_ptr<ASTNode> cond_ast;
-    if (!where_part.empty()) {
-        auto cond_tokens = tokenize(where_part);
-        cond_ast = parse_expression(cond_tokens);
+    if (!where_tokens.empty()) {
+        cond_ast = parse_expression(where_tokens);
     }
 
     bool always_true = false;

--- a/src/warpdb.cpp
+++ b/src/warpdb.cpp
@@ -97,21 +97,12 @@ QueryResult WarpDB::query(const std::string &expr) {
         throw std::runtime_error("Empty query expression");
     }
 
-    std::string upper = expr;
-    for (auto &c : upper) c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
-
-    std::string expr_part = expr;
-    std::string where_part;
-    auto where_pos = upper.find("WHERE");
-    if (where_pos != std::string::npos) {
-        expr_part = expr.substr(0, where_pos);
-        where_part = expr.substr(where_pos + 5);
-    }
+    auto tokens = tokenize(expr);
+    auto split = split_where_clause_tokens(tokens);
 
     std::unique_ptr<ASTNode> expr_ast;
     try {
-        auto expr_tokens = tokenize(expr_part);
-        expr_ast = parse_expression(expr_tokens);
+        expr_ast = parse_expression(split.expression_tokens);
     } catch (const std::exception &e) {
         throw std::runtime_error(std::string("Failed to parse expression: ") + e.what());
     }
@@ -125,10 +116,9 @@ QueryResult WarpDB::query(const std::string &expr) {
     std::string expr_cuda = expr_ast->to_cuda_expr();
 
     std::string condition_cuda;
-    if (!where_part.empty()) {
+    if (split.has_where) {
         try {
-            auto cond_tokens = tokenize(where_part);
-            auto cond_ast = parse_expression(cond_tokens);
+            auto cond_ast = parse_expression(split.where_tokens);
             validate_ast(cond_ast.get(), cols);
             condition_cuda = cond_ast->to_cuda_expr();
         } catch (const std::exception &e) {
@@ -564,20 +554,11 @@ QueryResult WarpDB::query_multi_gpu(const std::string &expr) {
         throw std::runtime_error("Host table not available for multi-GPU query");
     }
 
-    std::string upper = expr;
-    for (auto &c : upper) c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
-
-    std::string expr_part = expr;
-    std::string where_part;
-    auto where_pos = upper.find("WHERE");
-    if (where_pos != std::string::npos) {
-        expr_part = expr.substr(0, where_pos);
-        where_part = expr.substr(where_pos + 5);
-    }
+    auto tokens = tokenize(expr);
+    auto split = split_where_clause_tokens(tokens);
 
     std::unique_ptr<ASTNode> expr_ast;
-    auto expr_tokens = tokenize(expr_part);
-    expr_ast = parse_expression(expr_tokens);
+    expr_ast = parse_expression(split.expression_tokens);
 
     std::unordered_set<std::string> cols;
     for (const auto &c : host_table_.columns) {
@@ -588,9 +569,8 @@ QueryResult WarpDB::query_multi_gpu(const std::string &expr) {
     std::string expr_cuda = expr_ast->to_cuda_expr();
 
     std::string condition_cuda;
-    if (!where_part.empty()) {
-        auto cond_tokens = tokenize(where_part);
-        auto cond_ast = parse_expression(cond_tokens);
+    if (split.has_where) {
+        auto cond_ast = parse_expression(split.where_tokens);
         validate_ast(cond_ast.get(), cols);
         condition_cuda = cond_ast->to_cuda_expr();
     }
@@ -601,19 +581,9 @@ QueryResult WarpDB::query_multi_gpu(const std::string &expr) {
 QueryResult WarpDB::query_multi_gpu_csv(const std::string &csv_path,
                                         const std::string &expr,
                                         int rows_per_chunk) {
-    std::string upper = expr;
-    for (auto &c : upper) c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
-
-    std::string expr_part = expr;
-    std::string where_part;
-    auto where_pos = upper.find("WHERE");
-    if (where_pos != std::string::npos) {
-        expr_part = expr.substr(0, where_pos);
-        where_part = expr.substr(where_pos + 5);
-    }
-
-    auto expr_tokens = tokenize(expr_part);
-    auto expr_ast = parse_expression(expr_tokens);
+    auto tokens = tokenize(expr);
+    auto split = split_where_clause_tokens(tokens);
+    auto expr_ast = parse_expression(split.expression_tokens);
     std::ifstream file(csv_path);
     if (!file.is_open()) {
         throw std::runtime_error("Failed to open file: " + csv_path);
@@ -639,9 +609,8 @@ QueryResult WarpDB::query_multi_gpu_csv(const std::string &csv_path,
     std::string expr_cuda = expr_ast->to_cuda_expr();
 
     std::string condition_cuda;
-    if (!where_part.empty()) {
-        auto cond_tokens = tokenize(where_part);
-        auto cond_ast = parse_expression(cond_tokens);
+    if (split.has_where) {
+        auto cond_ast = parse_expression(split.where_tokens);
         validate_ast(cond_ast.get(), cols);
         condition_cuda = cond_ast->to_cuda_expr();
     }

--- a/tests/test_expression.cpp
+++ b/tests/test_expression.cpp
@@ -44,6 +44,30 @@ int main() {
     std::string code7 = ast7->to_cuda_expr();
     assert(code7 == "(-1.0f * (3.0f + 4.0f))");
 
+    // split WHERE on keyword token only
+    auto tokens8 = tokenize("price * 2 WHERE quantity >= 2");
+    auto split8 = split_where_clause_tokens(tokens8);
+    assert(split8.has_where);
+    auto expr8 = parse_expression(split8.expression_tokens);
+    auto where8 = parse_expression(split8.where_tokens);
+    assert(expr8->to_cuda_expr() == "(price[idx] * 2.0f)");
+    assert(where8->to_cuda_expr() == "(quantity[idx] >= 2.0f)");
+
+    // identifiers containing "where" must not split the clause
+    auto tokens9 = tokenize("somewhere_value + 1");
+    auto split9 = split_where_clause_tokens(tokens9);
+    assert(!split9.has_where);
+    assert(split9.where_tokens.empty());
+    auto expr9 = parse_expression(split9.expression_tokens);
+    assert(expr9->to_cuda_expr() == "(somewhere_value[idx] + 1.0f)");
+
+    auto tokens10 = tokenize("anyWHERE_metric + 3");
+    auto split10 = split_where_clause_tokens(tokens10);
+    assert(!split10.has_where);
+    assert(split10.where_tokens.empty());
+    auto expr10 = parse_expression(split10.expression_tokens);
+    assert(expr10->to_cuda_expr() == "(anyWHERE_metric[idx] + 3.0f)");
+
     std::cout << "All parser tests passed\n"; 
     return 0; 
 }


### PR DESCRIPTION
### Motivation
- Avoid brittle string `find("WHERE")` splitting which could split identifiers containing the substring `where` and produce incorrect parsing.
- Ensure the query parser splits at a genuine `TokenType::Keyword` whose value is exactly `WHERE` and preserve existing `... WHERE ...` semantics.
- Tokenize once per query to avoid reconstructing raw substrings and to feed parsers directly from token streams.

### Description
- Added `WhereClauseSplit` and `split_where_clause_tokens` (declared in `include/expression.hpp`, implemented in `src/expression.cpp`) to split a token stream at a `TokenType::Keyword` token whose `value == "WHERE"`.
- Replaced string-based `find("WHERE")` splitting in `WarpDB::query`, `WarpDB::query_multi_gpu`, and `WarpDB::query_multi_gpu_csv` to: tokenize once with `tokenize(expr)`, call `split_where_clause_tokens`, then `parse_expression` on `split.expression_tokens` and (if present) `split.where_tokens` to generate ASTs and CUDA expressions.
- Updated the CLI flow in `src/main.cu` to use tokenized splitting, produce AST previews from `split.expression_tokens` / `split.where_tokens`, and pass token vectors into the optimizer demo call.
- Changed the optimizer API to accept token vectors (`execute_query_optimized(const std::vector<Token> &expr_tokens, const std::vector<Token> &where_tokens, Table &table)`) and adapted `src/optimizer.cpp` to parse tokens directly instead of parsing raw substrings.
- Added parser tests in `tests/test_expression.cpp` that verify correct splitting for a legitimate `price * 2 WHERE quantity >= 2` query and that identifiers containing `where` (mixed case or as a substring) do not trigger a split.

### Testing
- Ran the standalone expression parser tests with `g++ -std=c++17 -Iinclude tests/test_expression.cpp src/expression.cpp -o /tmp/test_expression && /tmp/test_expression`, and they passed (`All parser tests passed`).
- Attempted full CMake build and `expression_test` target with `cmake` / `cmake --build`, but it failed in this environment because the CUDA toolkit (`nvcc`) is not available; this is an environment limitation and not a functional regression in the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e66a71b19c83288dbb05c22d2807a1)