### PR TITLE
Guard query_sql against multiple non-GROUP-BY SELECT expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,10 @@ arrow_arr = pa.Array._import_from_c(arr_capsule, schema_capsule)
 ./warpdb "SELECT SUM(price) FROM test GROUP BY quantity"
 # Limit results after sorting
 ./warpdb "SELECT price FROM test ORDER BY price DESC LIMIT 5"
+
+# Note: non-GROUP-BY SQL currently supports a single SELECT expression.
+# The following is not yet supported:
+# ./warpdb "SELECT price, quantity FROM test"
 ```
 
 ### Multi-GPU Example
@@ -312,6 +316,7 @@ The project has recently gained several improvements:
 - Currently supports a limited subset of SQL functionality
 - Only supports simple CSV files with basic data types
 - Basic support for joins, aggregations, ordering, LIMIT and OFFSET clauses, and HAVING filters
+- Non-GROUP-BY SQL execution supports only one SELECT expression
 - Limited error handling for malformed queries
 - Loading Parquet/Arrow/ORC files requires Apache Arrow
 - Building the Python module requires `pybind11` or disable it with

--- a/src/warpdb.cpp
+++ b/src/warpdb.cpp
@@ -505,6 +505,11 @@ QueryResult WarpDB::query_sql(const std::string &sql) {
     for (const auto &c : table_.columns) cols.insert(c.name);
     validate_query_ast(ast, cols);
 
+    if (!ast.group_by && ast.select_list.size() > 1) {
+        throw std::runtime_error(
+            "Multiple SELECT expressions are not yet supported in query_sql");
+    }
+
     if (!ast.joins.empty()) {
         throw std::runtime_error(
             "JOIN is parsed but not executed yet. SQL execution currently "

--- a/tests/sql_features_test.cpp
+++ b/tests/sql_features_test.cpp
@@ -8,6 +8,20 @@
 
 int main(){
     WarpDB db("data/test.csv");
+    auto single_expr = db.query_sql("SELECT price FROM test");
+    assert(single_expr.size() == 4);
+
+    bool multiple_expr_threw = false;
+    try {
+        (void)db.query_sql("SELECT price, quantity FROM test");
+    } catch (const std::runtime_error &e) {
+        multiple_expr_threw =
+            std::string(e.what()).find(
+                "Multiple SELECT expressions are not yet supported in query_sql") !=
+            std::string::npos;
+    }
+    assert(multiple_expr_threw);
+
     auto res = db.query_sql("SELECT SUM(price) FROM test GROUP BY quantity ORDER BY quantity ASC");
 
     HostTable h = load_csv_to_host("data/test.csv");


### PR DESCRIPTION
### Motivation
- Prevent silent truncation of non-`GROUP BY` queries that previously used only the first `SELECT` expression by either adding multi-column support or failing fast; this change implements the interim safe failure mode.

### Description
- Added an early runtime check in `WarpDB::query_sql` (right after `validate_query_ast`) that throws `"Multiple SELECT expressions are not yet supported in query_sql"` when `!ast.group_by` and `ast.select_list.size() > 1`.
- Extended `tests/sql_features_test.cpp` to assert that a single-expression `SELECT` still works and that a multi-expression non-`GROUP BY` `SELECT` throws the new descriptive error.
- Updated `README.md` examples and the Limitations section to document that non-`GROUP BY` SQL execution only supports a single `SELECT` expression.

### Testing
- Attempted to configure and build the SQL execution test target with `cmake -S . -B build && cmake --build build -j2 --target sql_features_test`, but configuration/build failed because the environment is missing the CUDA toolkit (`nvcc`), so the updated test could not be compiled or executed.
- No automated test runs completed in this environment due to the missing CUDA toolchain.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e66a730a7483288f88e7efb04dbddd)