### PR TITLE
Support SQL '=' equality semantics in WHERE/HAVING evaluators

### DIFF
--- a/include/eval_helpers.hpp
+++ b/include/eval_helpers.hpp
@@ -41,6 +41,7 @@ float eval_node(const ASTNode *node, const Context &ctx, int idx) {
         if (op == ">=") return l >= r;
         if (op == "<=") return l <= r;
         if (op == "==") return l == r;
+        if (op == "=") return l == r;
         if (op == "!=") return l != r;
     }
     return 0.0f;
@@ -50,4 +51,3 @@ template <typename Context>
 bool eval_condition(const ASTNode *node, const Context &ctx, int idx) {
     return eval_node(node, ctx, idx) != 0.0f;
 }
-

--- a/src/warpdb.cpp
+++ b/src/warpdb.cpp
@@ -212,6 +212,7 @@ float eval_having_node(const ASTNode *node, const AggData &gd) {
         if (op == ">=") return l >= r;
         if (op == "<=") return l <= r;
         if (op == "==") return l == r;
+        if (op == "=") return l == r;
         if (op == "!=") return l != r;
     }
     if (auto ag = dynamic_cast<const AggregationNode *>(node)) {

--- a/tests/sql_features_test.cpp
+++ b/tests/sql_features_test.cpp
@@ -69,8 +69,24 @@ int main(){
     auto offset_beyond = db.query_sql("SELECT price FROM test ORDER BY price DESC LIMIT 2 OFFSET 10");
     assert(offset_beyond.empty());
 
+    auto where_equal = db.query_sql("SELECT price FROM test WHERE price = 20");
+    auto where_double_equal = db.query_sql("SELECT price FROM test WHERE price == 20");
+    assert(where_equal.size() == where_double_equal.size());
+    for (size_t i = 0; i < where_equal.size(); ++i) {
+        assert(std::abs(where_equal[i] - where_double_equal[i]) < 1e-5);
+    }
+
     auto having = db.query_sql("SELECT SUM(price) FROM test GROUP BY quantity HAVING SUM(price) > 15 ORDER BY quantity ASC");
     assert(having.size() == 3);
+
+    auto having_equal = db.query_sql(
+        "SELECT SUM(price) FROM test GROUP BY quantity HAVING SUM(price) = 20 ORDER BY quantity ASC");
+    auto having_double_equal = db.query_sql(
+        "SELECT SUM(price) FROM test GROUP BY quantity HAVING SUM(price) == 20 ORDER BY quantity ASC");
+    assert(having_equal.size() == having_double_equal.size());
+    for (size_t i = 0; i < having_equal.size(); ++i) {
+        assert(std::abs(having_equal[i] - having_double_equal[i]) < 1e-5);
+    }
 
     auto float_group = db.query_sql(
         "SELECT SUM(price) FROM test GROUP BY price / 10.0 ORDER BY price / 10.0 ASC");


### PR DESCRIPTION
### Motivation
- The SQL parser already recognizes `=` as a comparison operator in `Parser::parse_comparison`, so evaluators must handle `=` consistently with `==` to avoid surprising behavior.
- Ensure row-level WHERE evaluation and aggregate HAVING evaluation treat `=` equivalently to `==` so queries using either form produce identical results.
- Add regression tests to validate parity between `=` and `==` in both WHERE and HAVING contexts.

### Description
- Added `=` handling in the row-level evaluator by updating `eval_node` in `include/eval_helpers.hpp` to treat `"="` the same as `"=="`.
- Added `=` handling in the aggregate evaluator by updating `eval_having_node` in `src/warpdb.cpp` to treat `"="` the same as `"=="`.
- Extended `tests/sql_features_test.cpp` to add assertions that `SELECT price FROM test WHERE price = 20` matches `WHERE price == 20`, and that `HAVING SUM(price) = 20` matches `HAVING SUM(price) == 20`.

### Testing
- Added unit/regression checks in `tests/sql_features_test.cpp` (these tests were added but not executed successfully in this environment).
- Attempted to configure and build the `sql_features_test` target and run the test, but CMake configuration failed due to missing CUDA toolkit/NVCC (`Failed to find nvcc`), so no test binaries were executed here.
- No automated tests were run successfully in this environment due to the CUDA dependency; tests should be executable in CI or a developer environment with the CUDA toolkit installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e66ddecd588328b2275b582a828c22)