### PR TITLE
Reject multi-key GROUP BY in query_sql

### DIFF
--- a/src/warpdb.cpp
+++ b/src/warpdb.cpp
@@ -328,6 +328,11 @@ std::vector<float> execute_group_by_gpu_sum(const QueryAST &ast, const Table &ta
 std::vector<float> execute_group_by(const QueryAST &ast,
                                     const HostTable &table,
                                     const std::vector<int> &rows) {
+    if (!ast.group_by || ast.group_by->keys.size() != 1) {
+        throw std::runtime_error(
+            "GROUP BY in query_sql currently supports exactly one key expression");
+    }
+
     auto *agg = dynamic_cast<AggregationNode *>(ast.select_list[0].get());
     if (!agg) throw std::runtime_error("Only aggregation queries supported with GROUP BY");
 
@@ -498,6 +503,10 @@ QueryResult WarpDB::query_sql(const std::string &sql) {
     if (!ast.group_by && ast.select_list.size() > 1) {
         throw std::runtime_error(
             "Multiple SELECT expressions are not yet supported in query_sql");
+    }
+    if (ast.group_by && ast.group_by->keys.size() != 1) {
+        throw std::runtime_error(
+            "GROUP BY in query_sql currently supports exactly one key expression");
     }
 
     if (!ast.joins.empty()) {

--- a/tests/sql_features_test.cpp
+++ b/tests/sql_features_test.cpp
@@ -97,5 +97,17 @@ int main(){
         assert(std::abs(float_group_desc[i] - expected_desc[i]) < 1e-5);
     }
 
+    bool multi_key_group_by_threw = false;
+    try {
+        (void)db.query_sql(
+            "SELECT SUM(price) FROM test GROUP BY quantity, price ORDER BY quantity ASC");
+    } catch (const std::runtime_error &e) {
+        multi_key_group_by_threw =
+            std::string(e.what()).find(
+                "GROUP BY in query_sql currently supports exactly one key expression") !=
+            std::string::npos;
+    }
+    assert(multi_key_group_by_threw);
+
     return 0;
 }


### PR DESCRIPTION
### Motivation
- Choose the short-term behavior to fail fast for unsupported multi-key grouping and provide a clear error instead of attempting a partial or incorrect implementation. 
- Ensure all execution paths (CPU and GPU fast-path) consistently enforce the same single-key `GROUP BY` contract.

### Description
- Add validation in `WarpDB::query_sql` to throw a descriptive `std::runtime_error` when `ast.group_by` exists and `ast.group_by->keys.size() != 1` with the message `"GROUP BY in query_sql currently supports exactly one key expression"`.
- Add the same single-key validation to the CPU grouping implementation in `execute_group_by` so the execution path enforces the same rule.
- Leave the GPU fast-path unchanged because `can_use_gpu_group_sum_fast_path` already returns false unless `ast.group_by->keys.size() == 1`, keeping behavior aligned.
- Add a regression test in `tests/sql_features_test.cpp` that issues a multi-key `GROUP BY` query and asserts the explicit failure message is thrown.

### Testing
- Added an automated regression test in `tests/sql_features_test.cpp` that verifies a two-key `GROUP BY` causes the new runtime error (test code included in the repo).
- Attempted to build the `sql_features_test` target with `cmake -S . -B build && cmake --build build -j4 --target sql_features_test`, but the build failed in this environment because the CUDA toolkit / `nvcc` was not available, so the test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e66ddf8af08328a98677250c5e8549)