### PR TITLE
Enforce single-expression SELECT in query_sql, including grouped queries

### DIFF
--- a/src/warpdb.cpp
+++ b/src/warpdb.cpp
@@ -495,9 +495,9 @@ QueryResult WarpDB::query_sql(const std::string &sql) {
     for (const auto &c : table_.columns) cols.insert(c.name);
     validate_query_ast(ast, cols);
 
-    if (!ast.group_by && ast.select_list.size() > 1) {
+    if (ast.select_list.size() != 1) {
         throw std::runtime_error(
-            "Multiple SELECT expressions are not yet supported in query_sql");
+            "query_sql currently supports a single SELECT expression only");
     }
 
     if (!ast.joins.empty()) {

--- a/tests/sql_features_test.cpp
+++ b/tests/sql_features_test.cpp
@@ -17,10 +17,22 @@ int main(){
     } catch (const std::runtime_error &e) {
         multiple_expr_threw =
             std::string(e.what()).find(
-                "Multiple SELECT expressions are not yet supported in query_sql") !=
+                "query_sql currently supports a single SELECT expression only") !=
             std::string::npos;
     }
     assert(multiple_expr_threw);
+
+    bool grouped_multiple_expr_threw = false;
+    try {
+        (void)db.query_sql(
+            "SELECT SUM(price), quantity FROM test GROUP BY quantity");
+    } catch (const std::runtime_error &e) {
+        grouped_multiple_expr_threw =
+            std::string(e.what()).find(
+                "query_sql currently supports a single SELECT expression only") !=
+            std::string::npos;
+    }
+    assert(grouped_multiple_expr_threw);
 
     auto res = db.query_sql("SELECT SUM(price) FROM test GROUP BY quantity ORDER BY quantity ASC");
 


### PR DESCRIPTION
### Motivation
- Prevent unsupported multi-expression projections from being executed since true multi-expression projection is not implemented, and ensure the same restriction applies to grouped queries as well as non-grouped queries.
- Make the runtime error message explicit about the current limitation to help users understand the restriction.

### Description
- Change the guard in `WarpDB::query_sql` to require exactly one SELECT expression by checking `ast.select_list.size() != 1` and throw a clear error when violated.
- Update the thrown message to `query_sql currently supports a single SELECT expression only` to clarify the limitation.
- Update `tests/sql_features_test.cpp` to expect the new error message for the existing multi-expression test and add a new test case that asserts `SELECT SUM(price), quantity FROM test GROUP BY quantity` fails with the same message.

### Testing
- Attempted to configure the project with `cmake -S . -B build`, but configuration failed because the CUDA toolkit (`nvcc`) is not available in the environment, so the test binaries could not be built or executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e66de2f33483289d637d74be880587)