### PR TITLE
Add HAVING &&/|| evaluation and composite HAVING tests

### DIFF
--- a/src/warpdb.cpp
+++ b/src/warpdb.cpp
@@ -207,6 +207,8 @@ float eval_having_node(const ASTNode *node, const AggData &gd) {
         if (op == "-") return l - r;
         if (op == "*") return l * r;
         if (op == "/") return l / r;
+        if (op == "&&") return (l != 0.0f) && (r != 0.0f);
+        if (op == "||") return (l != 0.0f) || (r != 0.0f);
         if (op == ">") return l > r;
         if (op == "<") return l < r;
         if (op == ">=") return l >= r;

--- a/tests/sql_features_test.cpp
+++ b/tests/sql_features_test.cpp
@@ -5,6 +5,7 @@
 #include <map>
 #include <algorithm>
 #include <cmath>
+#include <fstream>
 
 int main(){
     WarpDB db("data/test.csv");
@@ -96,6 +97,33 @@ int main(){
     for (size_t i = 0; i < expected_desc.size(); ++i) {
         assert(std::abs(float_group_desc[i] - expected_desc[i]) < 1e-5);
     }
+
+    const std::string composite_csv = "data/test_having_composite.csv";
+    {
+        std::ofstream out(composite_csv);
+        out << "price,quantity\n";
+        out << "6,1\n";
+        out << "7,1\n";
+        out << "50,2\n";
+    }
+
+    WarpDB having_db(composite_csv);
+
+    auto having_and = having_db.query_sql(
+        "SELECT SUM(price) FROM test_having_composite "
+        "GROUP BY quantity "
+        "HAVING SUM(price) > 10 AND COUNT(price) >= 2 "
+        "ORDER BY quantity ASC");
+    assert(having_and.size() == 1);
+    assert(std::abs(having_and[0] - 13.0f) < 1e-5);
+
+    auto having_or = having_db.query_sql(
+        "SELECT SUM(price) FROM test_having_composite "
+        "GROUP BY quantity "
+        "HAVING SUM(price) > 100 OR COUNT(price) = 1 "
+        "ORDER BY quantity ASC");
+    assert(having_or.size() == 1);
+    assert(std::abs(having_or[0] - 50.0f) < 1e-5);
 
     return 0;
 }


### PR DESCRIPTION
### Motivation
- HAVING expressions did not support logical composition, preventing combined aggregate predicates like `A AND B` or `A OR B` from being evaluated on the host path.
- The implementation should match the existing `eval_node` truthiness semantics where non-zero is true and zero is false.

### Description
- Implemented `&&` and `||` handling in `eval_having_node` for `BinaryOpNode` using non-zero truthiness in `src/warpdb.cpp`.
- Added composite HAVING coverage to `tests/sql_features_test.cpp` by creating a small CSV fixture and asserting results for `HAVING SUM(price) > 10 AND COUNT(price) >= 2` and `HAVING SUM(price) > 100 OR COUNT(price) = 1`.
- Added an `#include <fstream>` to the test file to enable writing the runtime CSV fixture.

### Testing
- Attempted to configure and build the `sql_features_test` target with `cmake -S . -B build && cmake --build build --target sql_features_test -j4` in this environment.
- The build could not proceed because the CUDA toolkit (`nvcc`) was not found, so tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e66de435708328a48d566e0e331971)