### PR TITLE
Make run_multi_gpu_jit_host return ColumnData

### DIFF
--- a/include/multi_gpu_utils.hpp
+++ b/include/multi_gpu_utils.hpp
@@ -7,6 +7,6 @@
 // Execute a JIT compiled expression across all available GPUs for the provided
 // host table chunk. Falls back to single GPU execution when only one device is
 // present.
-std::vector<float> run_multi_gpu_jit_host(const HostTable &host,
-                                          const std::string &expr_cuda,
-                                          const std::string &cond_cuda);
+ColumnData run_multi_gpu_jit_host(const HostTable &host,
+                                  const std::string &expr_cuda,
+                                  const std::string &cond_cuda);

--- a/src/main.cu
+++ b/src/main.cu
@@ -20,8 +20,9 @@ void run_multi_gpu_jit(const std::string &csv_path,
                        const std::string &cond_cuda) {
   HostTable host = load_csv_to_host(csv_path);
   auto results = run_multi_gpu_jit_host(host, expr_cuda, cond_cuda);
-  for (size_t i = 0; i < results.size(); ++i) {
-    std::cout << "MultiGPU Result[" << i << "] = " << results[i] << "\n";
+  const auto &out = std::get<std::vector<float>>(results);
+  for (size_t i = 0; i < out.size(); ++i) {
+    std::cout << "MultiGPU Result[" << i << "] = " << out[i] << "\n";
   }
 }
 
@@ -54,18 +55,21 @@ void run_multi_gpu_jit_large(const std::string &csv_path,
 
   bool finished = false;
   std::vector<DataType> schema;
-  std::vector<float> all_results;
+  ColumnData all_results = std::vector<float>{};
   while (!finished) {
     HostTable chunk = load_csv_chunk(file, rows_per_chunk, finished, column_names,
                                      ParsePolicy::Strict, &schema);
     if (chunk.num_rows() == 0 && finished)
       break;
     auto part = run_multi_gpu_jit_host(chunk, expr_cuda, cond_cuda);
-    all_results.insert(all_results.end(), part.begin(), part.end());
+    auto &dst = std::get<std::vector<float>>(all_results);
+    const auto &src = std::get<std::vector<float>>(part);
+    dst.insert(dst.end(), src.begin(), src.end());
   }
 
-  for (size_t i = 0; i < all_results.size(); ++i) {
-    std::cout << "Large MultiGPU Result[" << i << "] = " << all_results[i]
+  const auto &out = std::get<std::vector<float>>(all_results);
+  for (size_t i = 0; i < out.size(); ++i) {
+    std::cout << "Large MultiGPU Result[" << i << "] = " << out[i]
               << "\n";
   }
 }

--- a/src/multi_gpu_utils.cpp
+++ b/src/multi_gpu_utils.cpp
@@ -5,9 +5,9 @@
 // All CUDA runtime calls are wrapped in CUDA_CHECK, which throws
 // std::runtime_error on failure. This allows errors to propagate to callers
 // for handling while keeping this function's control flow simple.
-std::vector<float> run_multi_gpu_jit_host(const HostTable &host,
-                                          const std::string &expr_cuda,
-                                          const std::string &cond_cuda) {
+ColumnData run_multi_gpu_jit_host(const HostTable &host,
+                                  const std::string &expr_cuda,
+                                  const std::string &cond_cuda) {
     int original_device = 0;
     CUDA_CHECK(cudaGetDevice(&original_device));
     struct DeviceReset {
@@ -26,7 +26,7 @@ std::vector<float> run_multi_gpu_jit_host(const HostTable &host,
         CUDA_CHECK(cudaMemcpy(result.data(), d_out.get(),
                               sizeof(float) * host.num_rows(),
                               cudaMemcpyDeviceToHost));
-        return result;
+        return ColumnData(std::move(result));
     }
 
     int N = host.num_rows();
@@ -79,5 +79,5 @@ std::vector<float> run_multi_gpu_jit_host(const HostTable &host,
                               cudaMemcpyDeviceToHost));
     }
 
-    return results;
+    return ColumnData(std::move(results));
 }

--- a/src/warpdb.cpp
+++ b/src/warpdb.cpp
@@ -634,7 +634,7 @@ QueryResult WarpDB::query_multi_gpu_csv(const std::string &csv_path,
 
     bool finished = false;
     std::vector<DataType> schema;
-    std::vector<float> all_results;
+    ColumnData all_results = std::vector<float>{};
     while (!finished) {
         HostTable chunk =
             load_csv_chunk(file, rows_per_chunk, finished, column_names,
@@ -643,7 +643,9 @@ QueryResult WarpDB::query_multi_gpu_csv(const std::string &csv_path,
             break;
         }
         auto part = run_multi_gpu_jit_host(chunk, expr_cuda, condition_cuda);
-        all_results.insert(all_results.end(), part.begin(), part.end());
+        auto &dst = std::get<std::vector<float>>(all_results);
+        const auto &src = std::get<std::vector<float>>(part);
+        dst.insert(dst.end(), src.begin(), src.end());
     }
 
     return QueryResult(std::move(all_results));

--- a/tests/multi_gpu_sharding_test.cpp
+++ b/tests/multi_gpu_sharding_test.cpp
@@ -70,11 +70,12 @@ int main() {
     host.columns.push_back(std::move(str_col));
 
     auto results = run_multi_gpu_jit_host(host, "f32_col + 1.0f", "");
-    assert(static_cast<int>(results.size()) == rows);
+    const auto &out = std::get<std::vector<float>>(results);
+    assert(static_cast<int>(out.size()) == rows);
 
     for (int i = 0; i < rows; ++i) {
         float expected = f32_vec[i] + 1.0f;
-        assert(std::fabs(results[i] - expected) < 1e-6f);
+        assert(std::fabs(out[i] - expected) < 1e-6f);
     }
 
     if (device_count < 2) {


### PR DESCRIPTION
### Motivation
- The multi-GPU sharding path still returned `std::vector<float>` while the rest of the codebase moved to heterogeneous result types, so the multi-GPU API needs to return `ColumnData` to align with the new type system.

### Description
- Changed the signature of `run_multi_gpu_jit_host` from `std::vector<float>` to `ColumnData` in `include/multi_gpu_utils.hpp`.
- Updated `src/multi_gpu_utils.cpp` to wrap single-GPU and sharded multi-GPU float outputs into `ColumnData` while preserving existing sharding/upload logic.
- Updated call sites to consume the `ColumnData` result via `std::get<std::vector<float>>(...)` in `src/warpdb.cpp`, `src/main.cu`, and `tests/multi_gpu_sharding_test.cpp`.
- Kept the public behavior unchanged for float-result use-cases by explicitly extracting the float vector where needed.

### Testing
- Attempted to build with `cmake -S . -B build && cmake --build build -j2`, which failed in this environment because the CUDA toolkit / `nvcc` was not available. 
- No automated test binary runs completed in this environment due to the missing CUDA toolchain, and the updated multi-GPU sharding test was modified but not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6d09b0ebc8328b7a9db5c4c9c14c1)