### PR TITLE
Generalize GPU GROUP BY fast path beyond price/quantity SUM

### DIFF
--- a/include/jit.hpp
+++ b/include/jit.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include <string>
 #include "csv_loader.hpp"
 
@@ -18,6 +19,8 @@ void jit_compile_and_launch(const std::string &expr_code,
 size_t get_jit_compile_count();
 void reset_jit_cache();
 
+enum class GroupReduceOp { Sum, Min, Max };
+
 // JIT compile a kernel that groups rows by `key_expr_code` and sums
 // `val_expr_code`. The number of unique groups is written to d_count and
 // results are stored in d_out_vals and d_out_keys.
@@ -25,6 +28,20 @@ void jit_group_sum(const std::string &val_expr_code,
                    const std::string &key_expr_code, float *d_price,
                    int *d_quantity, float *d_out_vals, int *d_out_keys,
                    int *d_count, int N, int device_id = 0);
+
+// Reduce numeric values by integer keys on GPU. Keys must be Int32 or Int64
+// and values must be numeric. Returns number of unique groups and writes
+// grouped keys and aggregated values to output buffers.
+int jit_group_reduce_by_key(const void *d_keys, DataType key_type,
+                            const void *d_values, DataType value_type,
+                            GroupReduceOp op, int64_t *d_out_keys,
+                            float *d_out_vals, int N, int device_id = 0);
+
+// Count rows per key on GPU. Keys must be Int32 or Int64. Returns number of
+// unique groups and writes grouped keys and counts (as float) to outputs.
+int jit_group_count_by_key(const void *d_keys, DataType key_type,
+                           int64_t *d_out_keys, float *d_out_counts, int N,
+                           int device_id = 0);
 
 // Sort integer keys and corresponding values in place using a parallel GPU
 // implementation. When ascending is false results are sorted in descending
@@ -35,4 +52,3 @@ void jit_sort_pairs(int *d_keys, float *d_vals, int count, bool ascending,
 // Sort a single float array in-place using a parallel GPU implementation.
 void jit_sort_float(float *d_vals, int count, bool ascending,
                     int device_id = 0);
-

--- a/src/jit.cpp
+++ b/src/jit.cpp
@@ -13,6 +13,8 @@
 #include <thrust/reduce.h>
 #include <thrust/sort.h>
 #include <thrust/system/cuda/execution_policy.h>
+#include <thrust/transform.h>
+#include <thrust/iterator/constant_iterator.h>
 #include <unordered_map>
 #include <vector>
 #include <mutex>
@@ -473,6 +475,147 @@ void jit_group_sum(const std::string &val_expr_code,
   int host_count = static_cast<int>(reduce_end.first - out_keys_begin);
   CUDA_RUNTIME_CHECK(
       cudaMemcpy(d_count, &host_count, sizeof(int), cudaMemcpyHostToDevice));
+}
+
+template <typename T> struct DeviceToFloat {
+  __host__ __device__ float operator()(T v) const {
+    return static_cast<float>(v);
+  }
+};
+
+template <typename T> struct DeviceToInt64 {
+  __host__ __device__ int64_t operator()(T v) const {
+    return static_cast<int64_t>(v);
+  }
+};
+
+template <typename KeyT, typename ValueT, typename ReduceOp>
+int jit_group_reduce_impl(const void *d_keys_raw, const void *d_values_raw,
+                          int64_t *d_out_keys, float *d_out_vals, int N,
+                          ReduceOp reduce_op) {
+  auto exec_policy = thrust::cuda::par.on(0);
+  const auto *d_keys = static_cast<const KeyT *>(d_keys_raw);
+  const auto *d_values = static_cast<const ValueT *>(d_values_raw);
+
+  DeviceBuffer<KeyT> tmp_keys(static_cast<size_t>(N));
+  DeviceBuffer<float> tmp_vals(static_cast<size_t>(N));
+  CUDA_RUNTIME_CHECK(cudaMemcpy(tmp_keys.get(), d_keys, sizeof(KeyT) * static_cast<size_t>(N),
+                                cudaMemcpyDeviceToDevice));
+  thrust::transform(exec_policy, d_values, d_values + N,
+                    thrust::device_pointer_cast(tmp_vals.get()),
+                    DeviceToFloat<ValueT>());
+
+  auto tmp_keys_begin = thrust::device_pointer_cast(tmp_keys.get());
+  auto tmp_vals_begin = thrust::device_pointer_cast(tmp_vals.get());
+  thrust::sort_by_key(exec_policy, tmp_keys_begin, tmp_keys_begin + N, tmp_vals_begin);
+
+  DeviceBuffer<KeyT> reduced_keys(static_cast<size_t>(N));
+  auto reduced_keys_begin = thrust::device_pointer_cast(reduced_keys.get());
+  auto out_vals_begin = thrust::device_pointer_cast(d_out_vals);
+  auto reduce_end = thrust::reduce_by_key(exec_policy, tmp_keys_begin, tmp_keys_begin + N,
+                                          tmp_vals_begin, reduced_keys_begin,
+                                          out_vals_begin, thrust::equal_to<KeyT>(),
+                                          reduce_op);
+  int host_count = static_cast<int>(reduce_end.first - reduced_keys_begin);
+  thrust::transform(exec_policy, reduced_keys_begin, reduced_keys_begin + host_count,
+                    thrust::device_pointer_cast(d_out_keys), DeviceToInt64<KeyT>());
+  return host_count;
+}
+
+template <typename KeyT>
+int jit_group_count_impl(const void *d_keys_raw, int64_t *d_out_keys,
+                         float *d_out_counts, int N) {
+  auto exec_policy = thrust::cuda::par.on(0);
+  const auto *d_keys = static_cast<const KeyT *>(d_keys_raw);
+
+  DeviceBuffer<KeyT> tmp_keys(static_cast<size_t>(N));
+  CUDA_RUNTIME_CHECK(cudaMemcpy(tmp_keys.get(), d_keys, sizeof(KeyT) * static_cast<size_t>(N),
+                                cudaMemcpyDeviceToDevice));
+  auto tmp_keys_begin = thrust::device_pointer_cast(tmp_keys.get());
+  thrust::sort(exec_policy, tmp_keys_begin, tmp_keys_begin + N);
+
+  DeviceBuffer<KeyT> reduced_keys(static_cast<size_t>(N));
+  DeviceBuffer<int> reduced_counts(static_cast<size_t>(N));
+  auto reduced_keys_begin = thrust::device_pointer_cast(reduced_keys.get());
+  auto reduced_counts_begin = thrust::device_pointer_cast(reduced_counts.get());
+  auto reduce_end = thrust::reduce_by_key(
+      exec_policy, tmp_keys_begin, tmp_keys_begin + N,
+      thrust::make_constant_iterator(1), reduced_keys_begin, reduced_counts_begin);
+
+  int host_count = static_cast<int>(reduce_end.first - reduced_keys_begin);
+  thrust::transform(exec_policy, reduced_keys_begin, reduced_keys_begin + host_count,
+                    thrust::device_pointer_cast(d_out_keys), DeviceToInt64<KeyT>());
+  thrust::transform(exec_policy, reduced_counts_begin, reduced_counts_begin + host_count,
+                    thrust::device_pointer_cast(d_out_counts), DeviceToFloat<int>());
+  return host_count;
+}
+
+int jit_group_reduce_by_key(const void *d_keys, DataType key_type,
+                            const void *d_values, DataType value_type,
+                            GroupReduceOp op, int64_t *d_out_keys,
+                            float *d_out_vals, int N, int device_id) {
+  CUDA_RUNTIME_CHECK(cudaSetDevice(device_id));
+  if (N <= 0) return 0;
+
+  if (key_type == DataType::Int32) {
+    switch (value_type) {
+    case DataType::Int32:
+      if (op == GroupReduceOp::Sum) return jit_group_reduce_impl<int32_t, int32_t>(d_keys, d_values, d_out_keys, d_out_vals, N, thrust::plus<float>());
+      if (op == GroupReduceOp::Min) return jit_group_reduce_impl<int32_t, int32_t>(d_keys, d_values, d_out_keys, d_out_vals, N, thrust::minimum<float>());
+      return jit_group_reduce_impl<int32_t, int32_t>(d_keys, d_values, d_out_keys, d_out_vals, N, thrust::maximum<float>());
+    case DataType::Int64:
+      if (op == GroupReduceOp::Sum) return jit_group_reduce_impl<int32_t, int64_t>(d_keys, d_values, d_out_keys, d_out_vals, N, thrust::plus<float>());
+      if (op == GroupReduceOp::Min) return jit_group_reduce_impl<int32_t, int64_t>(d_keys, d_values, d_out_keys, d_out_vals, N, thrust::minimum<float>());
+      return jit_group_reduce_impl<int32_t, int64_t>(d_keys, d_values, d_out_keys, d_out_vals, N, thrust::maximum<float>());
+    case DataType::Float32:
+      if (op == GroupReduceOp::Sum) return jit_group_reduce_impl<int32_t, float>(d_keys, d_values, d_out_keys, d_out_vals, N, thrust::plus<float>());
+      if (op == GroupReduceOp::Min) return jit_group_reduce_impl<int32_t, float>(d_keys, d_values, d_out_keys, d_out_vals, N, thrust::minimum<float>());
+      return jit_group_reduce_impl<int32_t, float>(d_keys, d_values, d_out_keys, d_out_vals, N, thrust::maximum<float>());
+    case DataType::Float64:
+      if (op == GroupReduceOp::Sum) return jit_group_reduce_impl<int32_t, double>(d_keys, d_values, d_out_keys, d_out_vals, N, thrust::plus<float>());
+      if (op == GroupReduceOp::Min) return jit_group_reduce_impl<int32_t, double>(d_keys, d_values, d_out_keys, d_out_vals, N, thrust::minimum<float>());
+      return jit_group_reduce_impl<int32_t, double>(d_keys, d_values, d_out_keys, d_out_vals, N, thrust::maximum<float>());
+    case DataType::String:
+      break;
+    }
+  } else if (key_type == DataType::Int64) {
+    switch (value_type) {
+    case DataType::Int32:
+      if (op == GroupReduceOp::Sum) return jit_group_reduce_impl<int64_t, int32_t>(d_keys, d_values, d_out_keys, d_out_vals, N, thrust::plus<float>());
+      if (op == GroupReduceOp::Min) return jit_group_reduce_impl<int64_t, int32_t>(d_keys, d_values, d_out_keys, d_out_vals, N, thrust::minimum<float>());
+      return jit_group_reduce_impl<int64_t, int32_t>(d_keys, d_values, d_out_keys, d_out_vals, N, thrust::maximum<float>());
+    case DataType::Int64:
+      if (op == GroupReduceOp::Sum) return jit_group_reduce_impl<int64_t, int64_t>(d_keys, d_values, d_out_keys, d_out_vals, N, thrust::plus<float>());
+      if (op == GroupReduceOp::Min) return jit_group_reduce_impl<int64_t, int64_t>(d_keys, d_values, d_out_keys, d_out_vals, N, thrust::minimum<float>());
+      return jit_group_reduce_impl<int64_t, int64_t>(d_keys, d_values, d_out_keys, d_out_vals, N, thrust::maximum<float>());
+    case DataType::Float32:
+      if (op == GroupReduceOp::Sum) return jit_group_reduce_impl<int64_t, float>(d_keys, d_values, d_out_keys, d_out_vals, N, thrust::plus<float>());
+      if (op == GroupReduceOp::Min) return jit_group_reduce_impl<int64_t, float>(d_keys, d_values, d_out_keys, d_out_vals, N, thrust::minimum<float>());
+      return jit_group_reduce_impl<int64_t, float>(d_keys, d_values, d_out_keys, d_out_vals, N, thrust::maximum<float>());
+    case DataType::Float64:
+      if (op == GroupReduceOp::Sum) return jit_group_reduce_impl<int64_t, double>(d_keys, d_values, d_out_keys, d_out_vals, N, thrust::plus<float>());
+      if (op == GroupReduceOp::Min) return jit_group_reduce_impl<int64_t, double>(d_keys, d_values, d_out_keys, d_out_vals, N, thrust::minimum<float>());
+      return jit_group_reduce_impl<int64_t, double>(d_keys, d_values, d_out_keys, d_out_vals, N, thrust::maximum<float>());
+    case DataType::String:
+      break;
+    }
+  }
+
+  throw std::runtime_error("jit_group_reduce_by_key requires integer keys and numeric values");
+}
+
+int jit_group_count_by_key(const void *d_keys, DataType key_type,
+                           int64_t *d_out_keys, float *d_out_counts, int N,
+                           int device_id) {
+  CUDA_RUNTIME_CHECK(cudaSetDevice(device_id));
+  if (N <= 0) return 0;
+  if (key_type == DataType::Int32) {
+    return jit_group_count_impl<int32_t>(d_keys, d_out_keys, d_out_counts, N);
+  }
+  if (key_type == DataType::Int64) {
+    return jit_group_count_impl<int64_t>(d_keys, d_out_keys, d_out_counts, N);
+  }
+  throw std::runtime_error("jit_group_count_by_key requires integer keys");
 }
 
 void jit_sort_pairs(int *d_keys, float *d_vals, int count, bool ascending,

--- a/src/warpdb.cpp
+++ b/src/warpdb.cpp
@@ -16,6 +16,9 @@
 #include <unordered_set>
 #include <memory>
 #include "eval_helpers.hpp"
+#include <thrust/execution_policy.h>
+#include <thrust/functional.h>
+#include <thrust/transform.h>
 
 
 namespace {
@@ -234,83 +237,91 @@ bool eval_having(const QueryAST &ast, const AggData &gd) {
     return eval_having_node(ast.having.value().get(), gd) != 0.0f;
 }
 
-void collect_variable_names(const ASTNode *node,
-                            std::unordered_set<std::string> &names) {
-    if (!node) return;
-    if (auto var = dynamic_cast<const VariableNode *>(node)) {
-        names.insert(var->name);
-        return;
+const ColumnDesc *get_device_column(const Table &table, const std::string &name) {
+    for (const auto &col : table.columns) {
+        if (col.name == name) return &col;
     }
-    if (auto bin = dynamic_cast<const BinaryOpNode *>(node)) {
-        collect_variable_names(bin->left.get(), names);
-        collect_variable_names(bin->right.get(), names);
-        return;
-    }
-    if (auto fn = dynamic_cast<const FunctionCallNode *>(node)) {
-        for (const auto &arg : fn->args) {
-            collect_variable_names(arg.get(), names);
-        }
-        return;
-    }
-    if (auto agg = dynamic_cast<const AggregationNode *>(node)) {
-        collect_variable_names(agg->expr.get(), names);
-    }
+    return nullptr;
 }
 
-bool can_use_gpu_group_sum_fast_path(const QueryAST &ast) {
+bool is_numeric_type(DataType type) {
+    return type == DataType::Int32 || type == DataType::Int64 ||
+           type == DataType::Float32 || type == DataType::Float64;
+}
+
+bool can_use_gpu_group_fast_path(const QueryAST &ast, const Table &table) {
     if (!ast.group_by || ast.group_by->keys.size() != 1) return false;
     if (ast.select_list.size() != 1) return false;
     if (ast.where || ast.having || !ast.joins.empty()) return false;
 
     auto *agg = dynamic_cast<const AggregationNode *>(ast.select_list[0].get());
-    if (!agg || agg->agg != AggregationType::Sum) return false;
+    if (!agg) return false;
+    if (agg->agg == AggregationType::Count) return false;
 
     auto *key_var = dynamic_cast<const VariableNode *>(ast.group_by->keys[0].get());
-    if (!key_var || key_var->name != "quantity") return false;
+    auto *val_var = dynamic_cast<const VariableNode *>(agg->expr.get());
+    if (!key_var || !val_var) return false;
 
-    std::unordered_set<std::string> vars;
-    collect_variable_names(agg->expr.get(), vars);
-    for (const auto &name : vars) {
-        if (name != "price" && name != "quantity") {
-            return false;
-        }
-    }
-    return true;
+    const ColumnDesc *key_col = get_device_column(table, key_var->name);
+    const ColumnDesc *val_col = get_device_column(table, val_var->name);
+    if (!key_col || !val_col) return false;
+    if (!(key_col->type == DataType::Int32 || key_col->type == DataType::Int64)) return false;
+    return is_numeric_type(val_col->type);
 }
 
-std::vector<float> execute_group_by_gpu_sum(const QueryAST &ast, const Table &table) {
+std::vector<float> execute_group_by_gpu_fast(const QueryAST &ast, const Table &table) {
     const int N = table.num_rows;
-    float *d_price = table.get_column_ptr<float>("price");
-    int *d_quantity = table.get_column_ptr<int>("quantity");
-    if (!d_price || !d_quantity) {
-        throw std::runtime_error(
-            "GPU GROUP BY SUM fast path requires float 'price' and int 'quantity' columns");
+    const auto *agg = dynamic_cast<const AggregationNode *>(ast.select_list[0].get());
+    const auto *key_var = dynamic_cast<const VariableNode *>(ast.group_by->keys[0].get());
+    const auto *val_var = dynamic_cast<const VariableNode *>(agg->expr.get());
+    const ColumnDesc *key_col = get_device_column(table, key_var->name);
+    const ColumnDesc *val_col = get_device_column(table, val_var->name);
+    if (!key_col || !val_col) {
+        throw std::runtime_error("GPU GROUP BY fast path failed to resolve key/value columns");
     }
 
     DeviceBuffer<float> d_out_vals(static_cast<size_t>(N));
-    DeviceBuffer<int> d_out_keys(static_cast<size_t>(N));
-    DeviceBuffer<int> d_count(1);
+    DeviceBuffer<int64_t> d_out_keys(static_cast<size_t>(N));
 
-    const auto *agg = dynamic_cast<const AggregationNode *>(ast.select_list[0].get());
-    jit_group_sum(agg->expr->to_cuda_expr(), ast.group_by->keys[0]->to_cuda_expr(),
-                  d_price, d_quantity, d_out_vals.get(), d_out_keys.get(),
-                  d_count.get(), N);
+    GroupReduceOp op = GroupReduceOp::Sum;
+    if (agg->agg == AggregationType::Min) op = GroupReduceOp::Min;
+    if (agg->agg == AggregationType::Max) op = GroupReduceOp::Max;
 
     int host_count = 0;
-    CUDA_CHECK(cudaMemcpy(&host_count, d_count.get(), sizeof(int),
-                          cudaMemcpyDeviceToHost));
+    if (agg->agg == AggregationType::Avg) {
+        host_count = jit_group_reduce_by_key(
+            key_col->device_ptr.get(), key_col->type, val_col->device_ptr.get(),
+            val_col->type, GroupReduceOp::Sum, d_out_keys.get(), d_out_vals.get(), N);
+        if (host_count > 0) {
+            DeviceBuffer<float> d_counts(static_cast<size_t>(N));
+            DeviceBuffer<int64_t> d_count_keys(static_cast<size_t>(N));
+            int count_group_count = jit_group_count_by_key(
+                key_col->device_ptr.get(), key_col->type, d_count_keys.get(),
+                d_counts.get(), N);
+            if (count_group_count != host_count) {
+                throw std::runtime_error("GPU GROUP BY AVG fast path produced mismatched group counts");
+            }
+            thrust::transform(thrust::device, d_out_vals.get(), d_out_vals.get() + host_count,
+                              d_counts.get(), d_out_vals.get(), thrust::divides<float>());
+        }
+    } else {
+        host_count = jit_group_reduce_by_key(
+            key_col->device_ptr.get(), key_col->type, val_col->device_ptr.get(),
+            val_col->type, op, d_out_keys.get(), d_out_vals.get(), N);
+    }
+
     if (host_count <= 0) return {};
 
-    std::vector<int> keys(static_cast<size_t>(host_count));
+    std::vector<int64_t> keys(static_cast<size_t>(host_count));
     std::vector<float> vals(static_cast<size_t>(host_count));
     CUDA_CHECK(cudaMemcpy(keys.data(), d_out_keys.get(),
-                          sizeof(int) * static_cast<size_t>(host_count),
+                          sizeof(int64_t) * static_cast<size_t>(host_count),
                           cudaMemcpyDeviceToHost));
     CUDA_CHECK(cudaMemcpy(vals.data(), d_out_vals.get(),
                           sizeof(float) * static_cast<size_t>(host_count),
                           cudaMemcpyDeviceToHost));
 
-    std::vector<std::pair<int, float>> keyed;
+    std::vector<std::pair<int64_t, float>> keyed;
     keyed.reserve(static_cast<size_t>(host_count));
     for (int i = 0; i < host_count; ++i) {
         keyed.push_back({keys[static_cast<size_t>(i)], vals[static_cast<size_t>(i)]});
@@ -522,8 +533,8 @@ QueryResult WarpDB::query_sql(const std::string &sql) {
 
     ColumnData result = std::vector<float>{};
     if (ast.group_by) {
-        if (can_use_gpu_group_sum_fast_path(ast)) {
-            result = execute_group_by_gpu_sum(ast, table_);
+        if (can_use_gpu_group_fast_path(ast, table_)) {
+            result = execute_group_by_gpu_fast(ast, table_);
         } else {
             result = execute_group_by(ast, host_table_, rows);
         }

--- a/tests/sql_features_test.cpp
+++ b/tests/sql_features_test.cpp
@@ -164,5 +164,40 @@ int main(){
     }
     assert(multi_key_group_by_threw);
 
+    const std::string generic_gpu_csv = "data/test_group_fastpath_generic.csv";
+    {
+        std::ofstream out(generic_gpu_csv);
+        out << "gid,score\n";
+        out << "10,3\n";
+        out << "10,5\n";
+        out << "20,7\n";
+        out << "20,9\n";
+    }
+
+    WarpDB generic_gpu_db(generic_gpu_csv);
+    auto sum_generic = generic_gpu_db.query_sql(
+        "SELECT SUM(score) FROM test_group_fastpath_generic GROUP BY gid ORDER BY gid ASC");
+    assert(sum_generic.size() == 2);
+    assert(std::abs(sum_generic[0] - 8.0f) < 1e-5);
+    assert(std::abs(sum_generic[1] - 16.0f) < 1e-5);
+
+    auto avg_generic = generic_gpu_db.query_sql(
+        "SELECT AVG(score) FROM test_group_fastpath_generic GROUP BY gid ORDER BY gid ASC");
+    assert(avg_generic.size() == 2);
+    assert(std::abs(avg_generic[0] - 4.0f) < 1e-5);
+    assert(std::abs(avg_generic[1] - 8.0f) < 1e-5);
+
+    auto min_generic = generic_gpu_db.query_sql(
+        "SELECT MIN(score) FROM test_group_fastpath_generic GROUP BY gid ORDER BY gid ASC");
+    assert(min_generic.size() == 2);
+    assert(std::abs(min_generic[0] - 3.0f) < 1e-5);
+    assert(std::abs(min_generic[1] - 7.0f) < 1e-5);
+
+    auto max_generic = generic_gpu_db.query_sql(
+        "SELECT MAX(score) FROM test_group_fastpath_generic GROUP BY gid ORDER BY gid ASC");
+    assert(max_generic.size() == 2);
+    assert(std::abs(max_generic[0] - 5.0f) < 1e-5);
+    assert(std::abs(max_generic[1] - 9.0f) < 1e-5);
+
     return 0;
 }


### PR DESCRIPTION
### Motivation
- Remove the hardcoded `price`/`quantity` SUM fast-path so GROUP BY can use the GPU for more schemas and aggregation types.
- Allow the fast path when the grouping key is any integer column and the aggregated expression is any numeric column, enabling `SUM`, `AVG`, `MIN`, and `MAX` to dispatch to a GPU reduction.

### Description
- Replaced name-specific checks with `can_use_gpu_group_fast_path(const QueryAST&, const Table&)` which validates the key is `Int32`/`Int64` and the value is numeric (`Int32/Int64/Float32/Float64`).
- Replaced the old `execute_group_by_gpu_sum` with `execute_group_by_gpu_fast` which dispatches based on `AggregationType` and computes `AVG` as grouped `SUM` + grouped `COUNT` + device-side divide.
- Added typed GPU helpers to `include/jit.hpp`: `jit_group_reduce_by_key(...)` and `jit_group_count_by_key(...)` and a `GroupReduceOp` enum.
- Implemented new thrust-based reduce implementations in `src/jit.cpp` using `thrust::transform`, `thrust::sort_by_key`, and `thrust::reduce_by_key` with typed key/value handling and support for `Sum/Min/Max`.
- Hooked the new fast-path into SQL execution dispatch in `src/warpdb.cpp` and added tests in `tests/sql_features_test.cpp` that create a `gid,score` CSV and validate `SUM`, `AVG`, `MIN`, and `MAX` via the GPU fast path.

### Testing
- Added new SQL unit cases in `tests/sql_features_test.cpp` covering `SUM/AVG/MIN/MAX` grouped by a generic integer key; these tests are included in the source tree.
- Attempted to configure the build with `cmake -S . -B build`, but it failed because CUDA toolkit (`nvcc`) was not available in this environment (configure failed).
- Build (`cmake --build build -j4`) could not be run because configure did not complete due to the missing CUDA toolkit, so automated test execution was not possible here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6d09086d4832889f866957cd65bf7)