### PR TITLE
Validate multi-GPU CSV chunk size before file processing

### DIFF
--- a/src/warpdb.cpp
+++ b/src/warpdb.cpp
@@ -947,6 +947,10 @@ QueryResult WarpDB::query_multi_gpu(const std::string &expr) {
 QueryResult WarpDB::query_multi_gpu_csv(const std::string &csv_path,
                                         const std::string &expr,
                                         int rows_per_chunk) {
+    if (rows_per_chunk <= 0) {
+        throw std::runtime_error("rows_per_chunk must be > 0");
+    }
+
     auto tokens = tokenize(expr);
     auto split = split_where_clause_tokens(tokens);
     auto expr_ast = parse_expression(split.expression_tokens);

--- a/tests/multi_gpu_arbitrary_columns_test.cpp
+++ b/tests/multi_gpu_arbitrary_columns_test.cpp
@@ -2,6 +2,8 @@
 #include <cassert>
 #include <cmath>
 #include <iostream>
+#include <stdexcept>
+#include <string>
 
 int main() {
     WarpDB db("data/arbitrary_columns.csv");
@@ -13,6 +15,14 @@ int main() {
 
     auto streamed = WarpDB::query_multi_gpu_csv("data/arbitrary_columns.csv", "alpha * beta", 2);
     assert(streamed.size() == direct.size());
+
+    bool threw_invalid_chunk = false;
+    try {
+        (void)WarpDB::query_multi_gpu_csv("data/arbitrary_columns.csv", "alpha * beta", 0);
+    } catch (const std::runtime_error &e) {
+        threw_invalid_chunk = std::string(e.what()) == "rows_per_chunk must be > 0";
+    }
+    assert(threw_invalid_chunk);
     for (size_t i = 0; i < streamed.size(); ++i) {
         assert(std::fabs(streamed[i] - direct[i]) < 1e-5f);
     }


### PR DESCRIPTION
### Motivation
- Ensure callers of `WarpDB::query_multi_gpu_csv` fail fast when given an invalid `rows_per_chunk` to avoid hanging or undefined behavior during CSV streaming.

### Description
- Added a guard at the start of `WarpDB::query_multi_gpu_csv` in `src/warpdb.cpp` that throws `std::runtime_error("rows_per_chunk must be > 0")` when `rows_per_chunk <= 0` and placed it before any file open/read operations.
- Extended `tests/multi_gpu_arbitrary_columns_test.cpp` to call `query_multi_gpu_csv(..., 0)` and assert it immediately throws the expected `rows_per_chunk must be > 0` exception.
- Added the necessary headers (`<stdexcept>` and `<string>`) to the test file to support the new validation check.

### Testing
- Added a unit assertion in `tests/multi_gpu_arbitrary_columns_test.cpp` that verifies `query_multi_gpu_csv("data/arbitrary_columns.csv", "alpha * beta", 0)` throws the expected `std::runtime_error` (this is a code-level test included in the test binary).
- Attempted to configure the project with `cmake -S . -B build`, which failed due to a missing CUDA toolkit (`nvcc`), so no test binaries were built or executed in this environment.
- No automated test binaries were run successfully because the local environment lacks the required CUDA toolchain.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6d2bed88c83289fdc906c5945aeb8)