### PR TITLE
Skip zero-byte cudaMalloc for string columns; add test for all-empty strings

### DIFF
--- a/src/csv_loader.cpp
+++ b/src/csv_loader.cpp
@@ -404,7 +404,9 @@ Table upload_to_gpu(const HostTable &host) {
       void *d_offsets = nullptr;
       void *d_chars = nullptr;
       CUDA_CHECK(cudaMalloc(&d_offsets, sizeof(int32_t) * (N + 1)));
-      CUDA_CHECK(cudaMalloc(&d_chars, total_chars));
+      if (total_chars > 0) {
+        CUDA_CHECK(cudaMalloc(&d_chars, total_chars));
+      }
       CUDA_CHECK(cudaMemcpy(d_offsets, offsets.data(),
                             sizeof(int32_t) * (N + 1), cudaMemcpyHostToDevice));
       if (total_chars > 0) {

--- a/tests/string_column_query_test.cpp
+++ b/tests/string_column_query_test.cpp
@@ -32,6 +32,35 @@ int main() {
         assert(s == expected[i]);
     }
 
+    // Validate upload behavior when total string bytes == 0.
+    HostTable empty_strings_host;
+    HostColumn empty_name_col;
+    empty_name_col.name = "name";
+    empty_name_col.type = DataType::String;
+    empty_name_col.data = std::vector<std::string>{"", "", ""};
+    empty_strings_host.columns.push_back(std::move(empty_name_col));
+
+    HostColumn value_col;
+    value_col.name = "value";
+    value_col.type = DataType::Int32;
+    value_col.data = std::vector<int32_t>{1, 2, 3};
+    empty_strings_host.columns.push_back(std::move(value_col));
+
+    Table empty_strings_device = upload_to_gpu(empty_strings_host);
+    const int32_t* empty_offsets_dev =
+        empty_strings_device.get_column_ptr<int32_t>("name");
+    const char* empty_chars_dev = empty_strings_device.get_string_data("name");
+    assert(empty_offsets_dev != nullptr);
+    assert(empty_chars_dev == nullptr);
+
+    std::vector<int32_t> empty_offsets(empty_strings_host.num_rows() + 1);
+    CUDA_CHECK(cudaMemcpy(empty_offsets.data(), empty_offsets_dev,
+                          sizeof(int32_t) * (empty_strings_host.num_rows() + 1),
+                          cudaMemcpyDeviceToHost));
+    for (int v : empty_offsets) {
+        assert(v == 0);
+    }
+
     // Ensure queries still execute when string columns are present
     WarpDB db("data/string_test.csv", schema);
     auto res = db.query("price + quantity");


### PR DESCRIPTION
### Motivation
- Prevent a CUDA allocation error when uploading string columns that contain zero total bytes by avoiding a zero-size `cudaMalloc` while preserving offsets allocation and copy logic.
- Ensure the uploader still provides valid offsets (`N + 1`) and a null character buffer pointer when there are no characters to upload.

### Description
- Modified `upload_to_gpu` in `src/csv_loader.cpp` so `cudaMalloc(&d_chars, total_chars)` is only called when `total_chars > 0`, while leaving the offsets allocation (`N + 1`) unchanged and preserving the existing guarded `cudaMemcpy` for character data. 
- Left `d_chars` as `nullptr` for zero-byte string payloads and still set `col.string_data.reset(d_chars)` so consumers can see a null pointer when appropriate.
- Extended `tests/string_column_query_test.cpp` with an all-empty string column (`{"", "", ""}`) and a numeric column to validate that offsets are uploaded, all offsets are zero, and the device char pointer is `nullptr`.

### Testing
- Added assertions in `tests/string_column_query_test.cpp` exercising the zero-total-bytes case; these are unit test changes included in the repository test suite.
- Ran `cmake -S . -B build` in the environment, which failed to configure because the CUDA toolkit / `nvcc` was not found, so no build/tests were executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6d2c14a4883288671f492c87ef753)