### PR TITLE
Validate load_csv_chunk row field counts in strict and permissive modes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,6 +158,11 @@ add_executable(csv_loader_chunk_error_test
 target_link_libraries(csv_loader_chunk_error_test PRIVATE warpdb_lib)
 add_test(NAME csv_loader_chunk_error_test COMMAND csv_loader_chunk_error_test)
 
+add_executable(csv_loader_chunk_row_length_test
+    tests/csv_loader_chunk_row_length_test.cpp)
+target_link_libraries(csv_loader_chunk_row_length_test PRIVATE warpdb_lib)
+add_test(NAME csv_loader_chunk_row_length_test COMMAND csv_loader_chunk_row_length_test)
+
 add_executable(csv_loader_chunk_mixed_types_test
     tests/csv_loader_chunk_mixed_types_test.cpp)
 target_link_libraries(csv_loader_chunk_mixed_types_test PRIVATE warpdb_lib)

--- a/src/csv_loader.cpp
+++ b/src/csv_loader.cpp
@@ -447,6 +447,7 @@ HostTable load_csv_chunk(std::istream &stream, int max_rows, bool &finished,
 
   finished = false;
   int count = 0;
+  int input_row = 0;
   std::string line;
   std::vector<std::vector<std::string>> rows;
   while (count < max_rows) {
@@ -456,6 +457,20 @@ HostTable load_csv_chunk(std::istream &stream, int max_rows, bool &finished,
     }
     if (line.empty())
       continue;
+    ++input_row;
+
+    const size_t delimiter_count =
+        static_cast<size_t>(std::count(line.begin(), line.end(), ','));
+    const size_t field_count = delimiter_count + 1;
+    if (field_count != column_names.size()) {
+      std::cerr << "Row " << input_row << " has " << field_count
+                << " fields but " << column_names.size() << " were expected"
+                << std::endl;
+      if (policy == ParsePolicy::Strict) {
+        throw std::runtime_error("Incorrect number of fields in row");
+      }
+      continue;
+    }
 
     std::stringstream ss(line);
     std::string val;

--- a/tests/csv_loader_chunk_row_length_test.cpp
+++ b/tests/csv_loader_chunk_row_length_test.cpp
@@ -1,0 +1,50 @@
+#include "csv_loader.hpp"
+
+#include <cassert>
+#include <iostream>
+#include <sstream>
+#include <vector>
+
+int main() {
+    const std::string data =
+        "price,quantity\n"
+        "1.5,10\n"
+        "2.0,20,999\n"
+        "4.0,40\n";
+
+    std::istringstream ss_strict(data);
+    std::string header;
+    std::getline(ss_strict, header);
+    std::stringstream header_ss(header);
+    std::vector<std::string> columns;
+    std::string name;
+    while (std::getline(header_ss, name, ',')) columns.push_back(name);
+
+    bool finished = false;
+    bool threw = false;
+    try {
+        load_csv_chunk(ss_strict, 10, finished, columns, ParsePolicy::Strict);
+    } catch (const std::exception &) {
+        threw = true;
+    }
+    assert(threw && "Expected strict chunk parsing to throw on row width mismatch");
+
+    std::istringstream ss_perm(data);
+    std::getline(ss_perm, header);
+    std::stringstream header_ss_perm(header);
+    std::vector<std::string> columns_perm;
+    while (std::getline(header_ss_perm, name, ',')) columns_perm.push_back(name);
+
+    finished = false;
+    HostTable table =
+        load_csv_chunk(ss_perm, 10, finished, columns_perm, ParsePolicy::Permissive);
+    const auto &price = std::get<std::vector<float>>(table.columns[0].data);
+    const auto &quantity = std::get<std::vector<int32_t>>(table.columns[1].data);
+    assert(price.size() == 2 && quantity.size() == 2);
+    assert(price[0] == 1.5f && quantity[0] == 10);
+    assert(price[1] == 4.0f && quantity[1] == 40);
+    assert(finished);
+
+    std::cout << "csv loader chunk row length test passed\n";
+    return 0;
+}


### PR DESCRIPTION
### Motivation
- Ensure `load_csv_chunk` enforces per-row field-count validation to match `load_csv_to_host` semantics and avoid inconsistent parsing between chunked and full-load code paths.
- Provide clear handling for malformed rows according to `ParsePolicy` so callers can rely on consistent strict vs permissive behavior.

### Description
- In `load_csv_chunk` count delimiters (`','`) on each non-empty input line and compute `field_count = delimiter_count + 1` before parsing into `parsed_row`.
- If `field_count` differs from `column_names.size()` then in `Strict` mode throw `Incorrect number of fields in row` and in `Permissive` mode log to `std::cerr` and skip the row.
- Add `tests/csv_loader_chunk_row_length_test.cpp` that verifies `Strict` mode throws on malformed row widths and `Permissive` mode skips malformed rows while loading valid rows.
- Register the new test target in `CMakeLists.txt` so it is included in the test suite.

### Testing
- Added a focused test `csv_loader_chunk_row_length_test` covering both `Strict` and `Permissive` modes and confirmed the test file compiles conceptually against the changed API.
- Attempted to run `cmake -S . -B build && cmake --build build --target csv_loader_chunk_row_length_test csv_loader_chunk_error_test` to build the new and related tests, but CMake configure failed because the environment is missing the CUDA toolkit (`nvcc`), so builds were not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6d2c0424c8328a325885e1a3b43a4)