### PR TITLE
Improve OFFSET numeric parse diagnostics

### DIFF
--- a/src/expression.cpp
+++ b/src/expression.cpp
@@ -576,8 +576,15 @@ QueryAST Parser::parse_query() {
   if (current < toks.size() && toks[current].type == TokenType::Keyword &&
       toks[current].value == "OFFSET") {
     current++;
-    if (current >= toks.size() || toks[current].type != TokenType::Number)
-      throw std::runtime_error("Expected numeric value after OFFSET");
+
+    if (current >= toks.size() || toks[current].type != TokenType::Number) {
+      int l = current < toks.size() ? toks[current].line : toks.back().line;
+      int c = current < toks.size() ? toks[current].column : toks.back().column;
+      throw std::runtime_error("Expected numeric value after OFFSET at line " +
+                               std::to_string(l) + " column " +
+                               std::to_string(c));
+    }
+
     OffsetClause oc{std::stoi(toks[current].value)};
     current++;
     query.offset = oc;

--- a/tests/parsing_error_tests.cpp
+++ b/tests/parsing_error_tests.cpp
@@ -58,6 +58,23 @@ void test_malformed_exponent_missing_digits() {
     assert(threw && "Expected malformed exponent error");
 }
 
+
+void test_malformed_offset_reports_location() {
+    bool threw = false;
+    try {
+        auto tokens = tokenize("SELECT price FROM t OFFSET foo");
+        QueryAST q = parse_query(tokens);
+        (void)q;
+    } catch (const std::runtime_error &e) {
+        threw = true;
+        std::string msg = e.what();
+        assert(msg.find("Expected numeric value after OFFSET") != std::string::npos);
+        assert(msg.find("line") != std::string::npos);
+        assert(msg.find("column") != std::string::npos);
+    }
+    assert(threw && "Expected malformed OFFSET to fail");
+}
+
 void test_malformed_exponent_missing_digits_after_sign() {
     bool threw = false;
     try {
@@ -78,6 +95,7 @@ int main() {
     test_unbalanced_parentheses();
     test_malformed_exponent_missing_digits();
     test_malformed_exponent_missing_digits_after_sign();
+    test_malformed_offset_reports_location();
     std::cout << "All regression tests passed\n";
     return 0;
 }


### PR DESCRIPTION
### Motivation

- Make `OFFSET` numeric-argument validation consistent with `LIMIT` by providing precise location diagnostics when the numeric argument is missing or malformed.
- Improve developer/user experience by including `line` and `column` in the parser error for malformed `OFFSET` clauses.

### Description

- Update `parse_query` in `src/expression.cpp` so the `OFFSET` clause computes `line`/`column` the same way as `LIMIT` (use the current token when available, otherwise fall back to `toks.back()`), and throw a `std::runtime_error` with the formatted message `"Expected numeric value after OFFSET at line <n> column <m>"` when validation fails.
- Add a regression test `test_malformed_offset_reports_location` to `tests/parsing_error_tests.cpp` that tokenizes `SELECT price FROM t OFFSET foo`, calls `parse_query`, and asserts the thrown error message contains both `line` and `column` and the expected text.
- Wire the new test into the existing `parsing_error_tests` runner by invoking it from `main`.

### Testing

- Attempted to configure the test build with `cmake -S . -B build`, but CMake configuration failed in this environment because the CUDA toolkit (`nvcc`) was not available, so tests could not be executed here.
- No automated test run completed locally due to the environment limitation described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6d5d7a4e08328afc89f9024dc8a70)