### PR TITLE
Skip CUDA allocations for empty numeric CSV columns

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,11 @@ add_executable(csv_loader_error_test
 target_link_libraries(csv_loader_error_test PRIVATE warpdb_lib)
 add_test(NAME csv_loader_error_test COMMAND csv_loader_error_test)
 
+add_executable(csv_loader_header_only_gpu_test
+    tests/csv_loader_header_only_gpu_test.cpp)
+target_link_libraries(csv_loader_header_only_gpu_test PRIVATE warpdb_lib)
+add_test(NAME csv_loader_header_only_gpu_test COMMAND csv_loader_header_only_gpu_test)
+
 add_executable(csv_loader_row_length_test
     tests/csv_loader_row_length_test.cpp)
 target_link_libraries(csv_loader_row_length_test PRIVATE warpdb_lib)

--- a/data/header_only.csv
+++ b/data/header_only.csv
@@ -1,0 +1,1 @@
+price,quantity

--- a/src/csv_loader.cpp
+++ b/src/csv_loader.cpp
@@ -365,26 +365,30 @@ Table upload_to_gpu(const HostTable &host) {
     col.length = N;
 
     if (hcol.type != DataType::String) {
-      void *d_ptr = nullptr;
-      CUDA_CHECK(cudaMalloc(&d_ptr, dtype_size(hcol.type) * N));
-      col.device_ptr.reset(d_ptr);
+      if (N == 0) {
+        col.device_ptr.reset(nullptr);
+      } else {
+        void *d_ptr = nullptr;
+        CUDA_CHECK(cudaMalloc(&d_ptr, dtype_size(hcol.type) * N));
+        col.device_ptr.reset(d_ptr);
 
-      if (hcol.type == DataType::Int32) {
-        const auto &vec = std::get<std::vector<int32_t>>(hcol.data);
-        CUDA_CHECK(cudaMemcpy(col.device_ptr.get(), vec.data(),
-                              sizeof(int32_t) * N, cudaMemcpyHostToDevice));
-      } else if (hcol.type == DataType::Int64) {
-        const auto &vec = std::get<std::vector<int64_t>>(hcol.data);
-        CUDA_CHECK(cudaMemcpy(col.device_ptr.get(), vec.data(),
-                              sizeof(int64_t) * N, cudaMemcpyHostToDevice));
-      } else if (hcol.type == DataType::Float32) {
-        const auto &vec = std::get<std::vector<float>>(hcol.data);
-        CUDA_CHECK(cudaMemcpy(col.device_ptr.get(), vec.data(),
-                              sizeof(float) * N, cudaMemcpyHostToDevice));
-      } else if (hcol.type == DataType::Float64) {
-        const auto &vec = std::get<std::vector<double>>(hcol.data);
-        CUDA_CHECK(cudaMemcpy(col.device_ptr.get(), vec.data(),
-                              sizeof(double) * N, cudaMemcpyHostToDevice));
+        if (hcol.type == DataType::Int32) {
+          const auto &vec = std::get<std::vector<int32_t>>(hcol.data);
+          CUDA_CHECK(cudaMemcpy(col.device_ptr.get(), vec.data(),
+                                sizeof(int32_t) * N, cudaMemcpyHostToDevice));
+        } else if (hcol.type == DataType::Int64) {
+          const auto &vec = std::get<std::vector<int64_t>>(hcol.data);
+          CUDA_CHECK(cudaMemcpy(col.device_ptr.get(), vec.data(),
+                                sizeof(int64_t) * N, cudaMemcpyHostToDevice));
+        } else if (hcol.type == DataType::Float32) {
+          const auto &vec = std::get<std::vector<float>>(hcol.data);
+          CUDA_CHECK(cudaMemcpy(col.device_ptr.get(), vec.data(),
+                                sizeof(float) * N, cudaMemcpyHostToDevice));
+        } else if (hcol.type == DataType::Float64) {
+          const auto &vec = std::get<std::vector<double>>(hcol.data);
+          CUDA_CHECK(cudaMemcpy(col.device_ptr.get(), vec.data(),
+                                sizeof(double) * N, cudaMemcpyHostToDevice));
+        }
       }
     } else {
       const auto &vec = std::get<std::vector<std::string>>(hcol.data);

--- a/tests/csv_loader_header_only_gpu_test.cpp
+++ b/tests/csv_loader_header_only_gpu_test.cpp
@@ -1,0 +1,19 @@
+#include "csv_loader.hpp"
+#include <cassert>
+#include <iostream>
+
+int main() {
+    bool threw = false;
+    Table table;
+    try {
+        table = load_csv_to_gpu("data/header_only.csv");
+    } catch (const std::exception &) {
+        threw = true;
+    }
+
+    assert(!threw && "Expected load_csv_to_gpu to succeed for header-only CSV");
+    assert(table.num_rows == 0);
+
+    std::cout << "CSV header-only GPU load test passed\n";
+    return 0;
+}


### PR DESCRIPTION
### Motivation
- Avoid calling CUDA allocation and copy routines for numeric columns when there are zero rows, which can trigger unnecessary CUDA operations or errors when loading header-only CSVs.

### Description
- In `upload_to_gpu` (`src/csv_loader.cpp`) add an `if (N == 0)` short-circuit in the non-string branch so `col.device_ptr` remains null and no `cudaMalloc`/`cudaMemcpy` are invoked for numeric columns.
- Preserve existing string-column logic (offset and char buffer handling) because it already guards against empty content.
- Add a header-only fixture file `data/header_only.csv` and a regression test `tests/csv_loader_header_only_gpu_test.cpp` that calls `load_csv_to_gpu` and asserts `table.num_rows == 0` and no exception is thrown.
- Register the new test in `CMakeLists.txt` so it is run with the test suite.

### Testing
- Ran CMake configure with `cmake -S . -B build`, which failed in this environment because the CUDA toolkit / `nvcc` was not available, so the test binaries were not built or executed.
- No GPU-enabled test runs were executed in this environment due to the missing CUDA toolkit, so the new test has been added but not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6d5d69b748328a94c86329c36da76)