### PR TITLE
Rename JIT compilation unit to .cu and remove CMake source-language override

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,15 +35,11 @@ set(WARPDB_SRC
     src/csv_loader.cpp
     src/json_loader.cpp
     src/expression.cpp
-    src/jit.cpp
+    src/jit.cu
     src/arrow_utils.cpp
     src/multi_gpu_utils.cpp
     src/optimizer.cpp
 )
-
-# Ensure JIT compilation units are processed by NVCC so Thrust dispatches to the
-# GPU backend instead of falling back to host execution.
-set_source_files_properties(src/jit.cpp PROPERTIES LANGUAGE CUDA)
 
 
 if(Arrow_FOUND)
@@ -192,40 +188,40 @@ add_test(NAME json_loader_permissive_test COMMAND json_loader_permissive_test)
 
 add_executable(jit_error_test
     tests/jit_error_test.cpp
-    src/jit.cpp
+    src/jit.cu
 )
 target_link_libraries(jit_error_test PRIVATE CUDA::cudart CUDA::nvrtc CUDA::cuda_driver)
 add_test(NAME jit_error_test COMMAND jit_error_test)
 
 add_executable(jit_arch_test
     tests/jit_arch_test.cpp
-    src/jit.cpp
+    src/jit.cu
 )
 target_link_libraries(jit_arch_test PRIVATE CUDA::cudart CUDA::nvrtc CUDA::cuda_driver)
 add_test(NAME jit_arch_test COMMAND jit_arch_test)
 
 add_executable(jit_where_zero_test
     tests/jit_where_zero_test.cpp
-    src/jit.cpp
+    src/jit.cu
 )
 target_link_libraries(jit_where_zero_test PRIVATE CUDA::cudart CUDA::nvrtc CUDA::cuda_driver)
 add_test(NAME jit_where_zero_test COMMAND jit_where_zero_test)
 
 add_executable(jit_sort_parallel_test
     tests/jit_sort_parallel_test.cpp
-    src/jit.cpp
+    src/jit.cu
 )
 target_link_libraries(jit_sort_parallel_test PRIVATE CUDA::cudart CUDA::nvrtc CUDA::cuda_driver)
 add_test(NAME jit_sort_parallel_test COMMAND jit_sort_parallel_test)
 add_executable(jit_group_sum_test
     tests/jit_group_sum_test.cpp
-    src/jit.cpp
+    src/jit.cu
 )
 target_link_libraries(jit_group_sum_test PRIVATE CUDA::cudart CUDA::nvrtc CUDA::cuda_driver)
 add_test(NAME jit_group_sum_test COMMAND jit_group_sum_test)
 add_executable(jit_cache_test
     tests/jit_cache_test.cpp
-    src/jit.cpp
+    src/jit.cu
 )
 target_link_libraries(jit_cache_test PRIVATE CUDA::cudart CUDA::nvrtc CUDA::cuda_driver)
 add_test(NAME jit_cache_test COMMAND jit_cache_test)
@@ -243,7 +239,7 @@ add_library(warpdb_lib STATIC
     src/csv_loader.cpp
     src/json_loader.cpp
     src/expression.cpp
-    src/jit.cpp
+    src/jit.cu
     src/arrow_utils.cpp
     src/multi_gpu_utils.cpp
 )

--- a/src/jit.cu
+++ b/src/jit.cu
@@ -1,4 +1,4 @@
-// src/jit.cpp
+// src/jit.cu
 #include "jit.hpp"
 #include <cuda.h>
 #include <cuda_runtime.h>


### PR DESCRIPTION
### Motivation
- Avoid forcing a `.cpp` file through the CUDA toolchain, which breaks C++ language servers, IDE tooling, and linters; prefer file-extension-driven CUDA compilation.

### Description
- Renamed `src/jit.cpp` to `src/jit.cu` so NVCC is invoked based on the file extension.
- Updated all references in `CMakeLists.txt` from `src/jit.cpp` to `src/jit.cu`, including test targets and `warpdb_lib` sources.
- Removed the `set_source_files_properties(... LANGUAGE CUDA)` override from `CMakeLists.txt` to eliminate the anti-pattern.
- Updated the file header comment in the renamed source to reflect `src/jit.cu`.

### Testing
- Ran `cmake -S . -B build`, which exercised CMake parsing and CUDA discovery but failed in this environment because the CUDA toolkit compiler `nvcc` is not available (expected failure in CI-less environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7a6eb27c48328bb6f29e9ddee75a8)