### PR TITLE
Modernize include paths with target_include_directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,8 +28,6 @@ if(Arrow_FOUND)
     include_directories(${Arrow_INCLUDE_DIRS})
 endif()
 
-include_directories(include)
-
 set(WARPDB_SRC
     src/main.cu
     src/csv_loader.cpp
@@ -51,6 +49,7 @@ if(Arrow_FOUND)
 endif()
 
 add_executable(warpdb ${WARPDB_SRC})
+target_include_directories(warpdb PRIVATE include)
 
 set_target_properties(warpdb PROPERTIES
     CUDA_SEPARABLE_COMPILATION ON
@@ -247,6 +246,7 @@ add_library(warpdb_lib STATIC
     src/arrow_utils.cpp
     src/multi_gpu_utils.cpp
 )
+target_include_directories(warpdb_lib PUBLIC include)
 
 set_target_properties(warpdb_lib PROPERTIES
     CUDA_SEPARABLE_COMPILATION ON


### PR DESCRIPTION
### Motivation
- The project used the directory-scoped `include_directories(include)`, which pollutes the global include scope and does not express per-target header visibility. 
- Switch to target-based includes to make header visibility explicit and avoid leaking project headers into unrelated targets.

### Description
- Removed the global `include_directories(include)` call from `CMakeLists.txt`.
- Added `target_include_directories(warpdb PRIVATE include)` to scope headers to the `warpdb` executable.
- Added `target_include_directories(warpdb_lib PUBLIC include)` to expose library headers to dependents of `warpdb_lib`.

### Testing
- Ran `cmake -S . -B build` to validate configuration, which failed because the CUDA toolkit `nvcc` was not found in the environment, so full configuration/build could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7a6f32fbc83289a7ef0024b1ca621)