### PR TITLE
Consolidate warpdb_lib CMake target properties

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,7 +256,6 @@ target_link_libraries(warpdb_lib PUBLIC CUDA::nvrtc CUDA::cuda_driver)
 if(Arrow_FOUND)
     target_sources(warpdb_lib PRIVATE src/arrow_loader.cpp)
 endif()
-set_target_properties(warpdb_lib PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
 target_link_libraries(warpdb_lib PUBLIC CUDA::cudart CUDA::nvrtc CUDA::cuda_driver nlohmann_json::nlohmann_json)
 
 if(Arrow_FOUND)


### PR DESCRIPTION
### Motivation
- Remove a redundant `set_target_properties` call so `warpdb_lib` target properties (`CUDA_SEPARABLE_COMPILATION` and `POSITION_INDEPENDENT_CODE`) are declared in one place for clarity and to avoid duplication.

### Description
- Deleted the duplicated `set_target_properties(warpdb_lib PROPERTIES CUDA_SEPARABLE_COMPILATION ON)` and kept `CUDA_SEPARABLE_COMPILATION ON` together with `POSITION_INDEPENDENT_CODE ON` in a single `set_target_properties` block for `warpdb_lib` in `CMakeLists.txt`.

### Testing
- Verified the change by running `rg -n "set_target_properties\(warpdb_lib|CUDA_SEPARABLE_COMPILATION|POSITION_INDEPENDENT_CODE" CMakeLists.txt` which shows a single consolidated block and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7a6f7bd908328b05ba24459bd86ad)