### PR TITLE
Reject JOIN SQL at AST generation and enable multi-expression SELECT projection

### DIFF
--- a/include/warpdb.hpp
+++ b/include/warpdb.hpp
@@ -14,20 +14,34 @@
 
 class QueryResult {
 public:
-    QueryResult() : data_(std::vector<float>{}) {}
-    explicit QueryResult(ColumnData data) : data_(std::move(data)) {}
+    QueryResult() : columns_{std::vector<float>{}} {}
+    explicit QueryResult(ColumnData data) : columns_{std::move(data)} {}
+    explicit QueryResult(std::vector<ColumnData> columns)
+        : columns_(std::move(columns)) {
+        if (columns_.empty()) {
+            columns_.emplace_back(std::vector<float>{});
+        }
+    }
 
     size_t size() const {
-        return std::visit([](const auto &v) { return v.size(); }, data_);
+        return std::visit([](const auto &v) { return v.size(); }, columns_.front());
     }
 
     bool empty() const { return size() == 0; }
 
-    const ColumnData &data() const { return data_; }
+    size_t column_count() const { return columns_.size(); }
+
+    const ColumnData &data() const { return columns_.front(); }
+    const ColumnData &column_data(size_t idx) const { return columns_.at(idx); }
 
     template <typename T>
     const std::vector<T> &as() const {
-        return std::get<std::vector<T>>(data_);
+        return std::get<std::vector<T>>(columns_.front());
+    }
+
+    template <typename T>
+    const std::vector<T> &column_as(size_t idx) const {
+        return std::get<std::vector<T>>(columns_.at(idx));
     }
 
     float operator[](size_t idx) const {
@@ -42,11 +56,11 @@ public:
                     return static_cast<float>(v[idx]);
                 }
             },
-            data_);
+            columns_.front());
     }
 
 private:
-    ColumnData data_;
+    std::vector<ColumnData> columns_;
 };
 
 class WarpDB {
@@ -62,7 +76,7 @@ public:
 
     // Execute a full SQL query supporting WHERE/GROUP BY/HAVING/ORDER BY,
     // DISTINCT/LIMIT/OFFSET on a single loaded table.
-    // JOIN clauses are parsed by the SQL frontend but are not executed yet.
+    // JOIN clauses are currently rejected during SQL AST generation.
     QueryResult query_sql(const std::string &sql);
 
     // Execute a query using all available GPUs on the data loaded in this

--- a/src/expression.cpp
+++ b/src/expression.cpp
@@ -438,32 +438,14 @@ QueryAST Parser::parse_query() {
 
   query.from_table = toks[current++].value;
 
-  while (current < toks.size() && toks[current].type == TokenType::Keyword &&
-         toks[current].value == "JOIN") {
-    current++;
-
-    if (current >= toks.size() || toks[current].type != TokenType::Identifier) {
-      int l = current < toks.size() ? toks[current].line : toks.back().line;
-      int c = current < toks.size() ? toks[current].column : toks.back().column;
-      throw std::runtime_error("Expected table name after JOIN at line " +
-                               std::to_string(l) + " column " +
-                               std::to_string(c));
-    }
-    JoinClause jc;
-    jc.table = toks[current++].value;
-    expect_kw("ON");
-    size_t start = current;
-    while (current < end &&
-           !(toks[current].type == TokenType::Keyword &&
-             (toks[current].value == "WHERE" ||
-              toks[current].value == "GROUP" || toks[current].value == "ORDER" ||
-              toks[current].value == "HAVING" ||
-              toks[current].value == "JOIN" || toks[current].value == "LIMIT")))
-      current++;
-    std::vector<Token> cond(toks.begin() + start, toks.begin() + current);
-    cond.push_back({TokenType::End, "", 0, 0});
-    jc.condition = ::parse_expression(cond);
-    query.joins.push_back(std::move(jc));
+  if (current < toks.size() && toks[current].type == TokenType::Keyword &&
+      toks[current].value == "JOIN") {
+    int l = toks[current].line;
+    int c = toks[current].column;
+    throw std::runtime_error(
+        "JOIN is parsed but not supported for execution yet; rejecting during AST generation "
+        "until GPU hash-join or nested-loop join is implemented (line " +
+        std::to_string(l) + ", column " + std::to_string(c) + ")");
   }
 
   if (current < end && toks[current].type == TokenType::Keyword &&

--- a/src/warpdb.cpp
+++ b/src/warpdb.cpp
@@ -517,6 +517,17 @@ void apply_distinct(ColumnData &result) {
         result);
 }
 
+void sort_rows_by_order(const QueryAST &ast, const HostTable &table,
+                        std::vector<int> &rows) {
+    if (!ast.order_by) return;
+    std::stable_sort(rows.begin(), rows.end(), [&](int l, int r) {
+        float lk = eval_node(ast.order_by->expr.get(), table, l);
+        float rk = eval_node(ast.order_by->expr.get(), table, r);
+        if (ast.order_by->ascending) return lk < rk;
+        return lk > rk;
+    });
+}
+
 struct JoinVariableRef {
     std::string relation;
     std::string column;
@@ -689,24 +700,13 @@ float eval_join_node(const ASTNode *node, const HostTable &table, int left_idx,
 QueryPlan plan_query(QueryAST &&ast, const std::unordered_set<std::string> &cols, const Table &table) {
     validate_query_ast(ast, cols);
 
-    if (ast.select_list.size() != 1) {
-        throw std::runtime_error(
-            "query_sql currently supports a single SELECT expression only");
-    }
     if (ast.group_by && ast.group_by->keys.size() != 1) {
         throw std::runtime_error(
             "GROUP BY in query_sql currently supports exactly one key expression");
     }
-    if (!ast.joins.empty()) {
-        if (ast.joins.size() != 1) {
-            throw std::runtime_error(
-                "JOIN execution currently supports exactly one JOIN clause");
-        }
-        if (ast.group_by || ast.having || ast.order_by) {
-            throw std::runtime_error(
-                "JOIN execution currently supports SELECT/WHERE/DISTINCT/LIMIT/OFFSET "
-                "without GROUP BY, HAVING, or ORDER BY");
-        }
+    if (ast.group_by && ast.select_list.size() != 1) {
+        throw std::runtime_error(
+            "GROUP BY queries currently support exactly one SELECT expression");
     }
 
     QueryPlan plan;
@@ -721,7 +721,8 @@ QueryPlan plan_query(QueryAST &&ast, const std::unordered_set<std::string> &cols
         return plan;
     }
 
-    if (dynamic_cast<VariableNode *>(plan.ast.select_list[0].get())) {
+    if (plan.ast.select_list.size() == 1 &&
+        dynamic_cast<VariableNode *>(plan.ast.select_list[0].get())) {
         plan.execution_kind = PlanExecutionKind::SelectColumn;
     } else {
         plan.execution_kind = PlanExecutionKind::SelectExpression;
@@ -732,18 +733,24 @@ QueryPlan plan_query(QueryAST &&ast, const std::unordered_set<std::string> &cols
 QueryResult execute_plan(const QueryPlan &plan, const Table &table,
                          const HostTable &host_table) {
     std::vector<int> rows = filter_rows(plan.ast, host_table);
-
-    ColumnData result = std::vector<float>{};
     if (plan.ast.group_by) {
+        ColumnData result = std::vector<float>{};
         if (plan.execution_kind == PlanExecutionKind::GroupByGpuSum) {
             result = execute_group_by_gpu_fast(plan.ast, table);
         } else {
             result = execute_group_by(plan.ast, host_table, rows);
         }
-    } else {
+        if (plan.ast.distinct) {
+            apply_distinct(result);
+        }
+        apply_limit_offset(plan.ast, result);
+        return QueryResult(std::move(result));
+    }
+
+    if (plan.ast.select_list.size() == 1) {
+        ColumnData result = std::vector<float>{};
         if (plan.execution_kind == PlanExecutionKind::SelectColumn) {
-            auto *var =
-                dynamic_cast<VariableNode *>(plan.ast.select_list[0].get());
+            auto *var = dynamic_cast<VariableNode *>(plan.ast.select_list[0].get());
             const HostColumn *col = host_table.get_column(var->name);
             if (!col) {
                 throw std::runtime_error("Unknown column in SELECT: " + var->name);
@@ -758,14 +765,48 @@ QueryResult execute_plan(const QueryPlan &plan, const Table &table,
         if (plan.ast.order_by) {
             apply_order_by(plan.ast, host_table, rows, result);
         }
+        if (plan.ast.distinct) {
+            apply_distinct(result);
+        }
+        apply_limit_offset(plan.ast, result);
+        return QueryResult(std::move(result));
     }
 
     if (plan.ast.distinct) {
-        apply_distinct(result);
+        throw std::runtime_error(
+            "DISTINCT with multiple SELECT expressions is not supported yet");
     }
 
-    apply_limit_offset(plan.ast, result);
-    return QueryResult(std::move(result));
+    sort_rows_by_order(plan.ast, host_table, rows);
+    const size_t off =
+        plan.ast.offset ? static_cast<size_t>(std::max(plan.ast.offset->count, 0)) : 0;
+    const size_t start = std::min(off, rows.size());
+    size_t end = rows.size();
+    if (plan.ast.limit) {
+        end = std::min(end, start + static_cast<size_t>(std::max(plan.ast.limit->count, 0)));
+    }
+
+    std::vector<int> projected_rows(rows.begin() + static_cast<std::ptrdiff_t>(start),
+                                    rows.begin() + static_cast<std::ptrdiff_t>(end));
+    std::vector<ColumnData> projected;
+    projected.reserve(plan.ast.select_list.size());
+    for (const auto &expr : plan.ast.select_list) {
+        if (auto *var = dynamic_cast<VariableNode *>(expr.get())) {
+            const HostColumn *col = host_table.get_column(var->name);
+            if (!col) {
+                throw std::runtime_error("Unknown column in SELECT: " + var->name);
+            }
+            projected.push_back(select_typed_column(*col, projected_rows));
+            continue;
+        }
+        std::vector<float> out;
+        out.reserve(projected_rows.size());
+        for (int idx : projected_rows) {
+            out.push_back(eval_node(expr.get(), host_table, idx));
+        }
+        projected.emplace_back(std::move(out));
+    }
+    return QueryResult(std::move(projected));
 }
 
 } // namespace
@@ -781,132 +822,6 @@ QueryResult WarpDB::query_sql(const std::string &sql) {
 
     std::unordered_set<std::string> cols;
     for (const auto &c : table_.columns) cols.insert(c.name);
-
-    if (!ast.joins.empty()) {
-        validate_query_ast(ast, cols);
-        if (ast.select_list.size() != 1) {
-            throw std::runtime_error(
-                "query_sql currently supports a single SELECT expression only");
-        }
-        if (ast.joins.size() != 1) {
-            throw std::runtime_error(
-                "JOIN execution currently supports exactly one JOIN clause");
-        }
-        if (ast.group_by || ast.having || ast.order_by) {
-            throw std::runtime_error(
-                "JOIN execution currently supports SELECT/WHERE/DISTINCT/LIMIT/OFFSET "
-                "without GROUP BY, HAVING, or ORDER BY");
-        }
-
-        auto [left_rows, right_rows] = build_inner_join_rows(ast, host_table_);
-        ColumnData result = std::vector<float>{};
-
-        if (auto *var = dynamic_cast<VariableNode *>(ast.select_list[0].get())) {
-            auto qualified = parse_join_variable_name(var->name);
-            if (!qualified) {
-                throw std::runtime_error(
-                    "JOIN SELECT column must be qualified (e.g. a.col or b.col)");
-            }
-            const HostColumn *col = resolve_join_column(host_table_, qualified->relation,
-                                                        ast.from_table, ast.joins[0].table,
-                                                        qualified->column);
-            switch (col->type) {
-            case DataType::Int32: {
-                const auto &src = std::get<std::vector<int32_t>>(col->data);
-                std::vector<int32_t> out;
-                out.reserve(left_rows.size());
-                for (size_t i = 0; i < left_rows.size(); ++i) {
-                    if (ast.where && eval_join_node(ast.where.value().get(), host_table_,
-                                                    left_rows[i], right_rows[i],
-                                                    ast.from_table, ast.joins[0].table) == 0.0f)
-                        continue;
-                    int idx = qualified->relation == ast.from_table ? left_rows[i] : right_rows[i];
-                    out.push_back(src[idx]);
-                }
-                result = std::move(out);
-                break;
-            }
-            case DataType::Int64: {
-                const auto &src = std::get<std::vector<int64_t>>(col->data);
-                std::vector<int64_t> out;
-                out.reserve(left_rows.size());
-                for (size_t i = 0; i < left_rows.size(); ++i) {
-                    if (ast.where && eval_join_node(ast.where.value().get(), host_table_,
-                                                    left_rows[i], right_rows[i],
-                                                    ast.from_table, ast.joins[0].table) == 0.0f)
-                        continue;
-                    int idx = qualified->relation == ast.from_table ? left_rows[i] : right_rows[i];
-                    out.push_back(src[idx]);
-                }
-                result = std::move(out);
-                break;
-            }
-            case DataType::Float32: {
-                const auto &src = std::get<std::vector<float>>(col->data);
-                std::vector<float> out;
-                out.reserve(left_rows.size());
-                for (size_t i = 0; i < left_rows.size(); ++i) {
-                    if (ast.where && eval_join_node(ast.where.value().get(), host_table_,
-                                                    left_rows[i], right_rows[i],
-                                                    ast.from_table, ast.joins[0].table) == 0.0f)
-                        continue;
-                    int idx = qualified->relation == ast.from_table ? left_rows[i] : right_rows[i];
-                    out.push_back(src[idx]);
-                }
-                result = std::move(out);
-                break;
-            }
-            case DataType::Float64: {
-                const auto &src = std::get<std::vector<double>>(col->data);
-                std::vector<double> out;
-                out.reserve(left_rows.size());
-                for (size_t i = 0; i < left_rows.size(); ++i) {
-                    if (ast.where && eval_join_node(ast.where.value().get(), host_table_,
-                                                    left_rows[i], right_rows[i],
-                                                    ast.from_table, ast.joins[0].table) == 0.0f)
-                        continue;
-                    int idx = qualified->relation == ast.from_table ? left_rows[i] : right_rows[i];
-                    out.push_back(src[idx]);
-                }
-                result = std::move(out);
-                break;
-            }
-            case DataType::String: {
-                const auto &src = std::get<std::vector<std::string>>(col->data);
-                std::vector<std::string> out;
-                out.reserve(left_rows.size());
-                for (size_t i = 0; i < left_rows.size(); ++i) {
-                    if (ast.where && eval_join_node(ast.where.value().get(), host_table_,
-                                                    left_rows[i], right_rows[i],
-                                                    ast.from_table, ast.joins[0].table) == 0.0f)
-                        continue;
-                    int idx = qualified->relation == ast.from_table ? left_rows[i] : right_rows[i];
-                    out.push_back(src[idx]);
-                }
-                result = std::move(out);
-                break;
-            }
-            }
-        } else {
-            auto &out = std::get<std::vector<float>>(result);
-            out.reserve(left_rows.size());
-            for (size_t i = 0; i < left_rows.size(); ++i) {
-                if (ast.where && eval_join_node(ast.where.value().get(), host_table_,
-                                                left_rows[i], right_rows[i], ast.from_table,
-                                                ast.joins[0].table) == 0.0f)
-                    continue;
-                out.push_back(eval_join_node(ast.select_list[0].get(), host_table_,
-                                             left_rows[i], right_rows[i], ast.from_table,
-                                             ast.joins[0].table));
-            }
-        }
-
-        if (ast.distinct) {
-            apply_distinct(result);
-        }
-        apply_limit_offset(ast, result);
-        return QueryResult(std::move(result));
-    }
 
     QueryPlan plan = plan_query(std::move(ast), cols, table_);
     return execute_plan(plan, table_, host_table_);

--- a/tests/join_not_supported_test.cpp
+++ b/tests/join_not_supported_test.cpp
@@ -5,15 +5,17 @@
 int main() {
     WarpDB db("data/test.csv");
 
-    auto joined = db.query_sql(
-        "SELECT right.price FROM left JOIN right ON left.quantity = right.quantity "
-        "WHERE left.price > 10");
-    const auto &vals = joined.as<float>();
-    assert(vals.size() == 4);
-    assert(vals[0] == 20.0f);
-    assert(vals[1] == 15.25f);
-    assert(vals[2] == 30.0f);
-    assert(vals[3] == 10.5f);
+    bool rejected_join = false;
+    try {
+        (void)db.query_sql(
+            "SELECT right.price FROM left JOIN right ON left.quantity = right.quantity "
+            "WHERE left.price > 10");
+    } catch (const std::runtime_error &e) {
+        rejected_join = std::string(e.what()).find(
+                            "JOIN is parsed but not supported for execution yet") !=
+                        std::string::npos;
+    }
+    assert(rejected_join);
 
     return 0;
 }

--- a/tests/optimizer_test.cpp
+++ b/tests/optimizer_test.cpp
@@ -67,33 +67,18 @@ static void test_real_stats_prevent_elimination() {
     assert(!always_false);
 }
 
-static void test_extract_equi_join_predicates() {
+static void test_join_is_rejected_during_ast_generation() {
     auto tokens = tokenize(
         "SELECT a.v FROM a JOIN b ON a.id = b.a_id JOIN c ON b.id = c.b_id");
-    QueryAST ast = parse_query(tokens);
-    auto predicates = extract_equi_join_predicates(ast);
-    assert(predicates.size() == 2);
-    assert(predicates[0].left_relation == "a");
-    assert(predicates[0].left_column == "id");
-    assert(predicates[0].right_relation == "b");
-    assert(predicates[0].right_column == "a_id");
-}
-
-static void test_build_greedy_join_plan_prefers_low_ndv_join() {
-    auto tokens = tokenize(
-        "SELECT a.v FROM a JOIN b ON a.id = b.a_id JOIN c ON b.id = c.b_id");
-    QueryAST ast = parse_query(tokens);
-
-    std::unordered_map<std::string, RelationStats> stats;
-    stats["a"] = RelationStats{"a", 100000.0, {{"id", 100000.0}}};
-    stats["b"] = RelationStats{"b", 1000.0, {{"a_id", 1000.0}, {"id", 1000.0}}};
-    stats["c"] = RelationStats{"c", 500000.0, {{"b_id", 1000.0}}};
-
-    JoinPlan plan = build_greedy_join_plan(ast, stats);
-    assert(plan.steps.size() == 3);
-    assert(plan.steps[0].relation == "b");
-    assert(plan.steps[1].relation == "a");
-    assert(plan.steps[2].relation == "c");
+    bool rejected_join = false;
+    try {
+        (void)parse_query(tokens);
+    } catch (const std::runtime_error &e) {
+        rejected_join = std::string(e.what()).find(
+                            "JOIN is parsed but not supported for execution yet") !=
+                        std::string::npos;
+    }
+    assert(rejected_join);
 }
 
 static void test_estimate_equi_join_rows_uses_max_ndv() {
@@ -105,8 +90,7 @@ int main() {
     test_missing_stats_skip_elimination();
     test_analyze_condition_always_false();
     test_real_stats_prevent_elimination();
-    test_extract_equi_join_predicates();
-    test_build_greedy_join_plan_prefers_low_ndv_join();
+    test_join_is_rejected_during_ast_generation();
     test_estimate_equi_join_rows_uses_max_ndv();
     std::cout << "Optimizer tests passed\n";
     return 0;

--- a/tests/query_parser_test.cpp
+++ b/tests/query_parser_test.cpp
@@ -5,13 +5,15 @@
 int main() {
     std::string q = "SELECT SUM(price), quantity FROM sales JOIN items ON sales.id = items.id WHERE price > 10 GROUP BY quantity ORDER BY price DESC LIMIT 5";
     auto tokens = tokenize(q);
-    QueryAST ast = parse_query(tokens);
-    assert(ast.select_list.size() == 2);
-    assert(!ast.joins.empty());
-    assert(ast.where.has_value());
-    assert(ast.group_by.has_value());
-    assert(ast.order_by.has_value());
-    assert(ast.limit.has_value());
+    bool rejected_join = false;
+    try {
+        (void)parse_query(tokens);
+    } catch (const std::runtime_error &e) {
+        rejected_join = std::string(e.what()).find(
+                            "JOIN is parsed but not supported for execution yet") !=
+                        std::string::npos;
+    }
+    assert(rejected_join);
 
     std::string order_limit_q = "SELECT price FROM sales ORDER BY price LIMIT 5";
     auto order_limit_tokens = tokenize(order_limit_q);

--- a/tests/sql_features_test.cpp
+++ b/tests/sql_features_test.cpp
@@ -12,16 +12,14 @@ int main(){
     auto single_expr = db.query_sql("SELECT price FROM test");
     assert(single_expr.size() == 4);
 
-    bool multiple_expr_threw = false;
-    try {
-        (void)db.query_sql("SELECT price, quantity FROM test");
-    } catch (const std::runtime_error &e) {
-        multiple_expr_threw =
-            std::string(e.what()).find(
-                "query_sql currently supports a single SELECT expression only") !=
-            std::string::npos;
-    }
-    assert(multiple_expr_threw);
+    auto multiple_expr = db.query_sql("SELECT price, quantity FROM test");
+    assert(multiple_expr.column_count() == 2);
+    const auto &prices_sel = multiple_expr.column_as<float>(0);
+    const auto &qty_sel = multiple_expr.column_as<int32_t>(1);
+    assert(prices_sel.size() == 4);
+    assert(qty_sel.size() == 4);
+    assert(std::abs(prices_sel[0] - 10.5f) < 1e-5);
+    assert(qty_sel[0] == 3);
 
     bool grouped_multiple_expr_threw = false;
     try {
@@ -30,7 +28,7 @@ int main(){
     } catch (const std::runtime_error &e) {
         grouped_multiple_expr_threw =
             std::string(e.what()).find(
-                "query_sql currently supports a single SELECT expression only") !=
+                "GROUP BY queries currently support exactly one SELECT expression") !=
             std::string::npos;
     }
     assert(grouped_multiple_expr_threw);


### PR DESCRIPTION
### Motivation
- Prevent execution of parsed-but-unimplemented JOINs by rejecting JOIN queries early during AST generation until a proper join implementation (GPU hash-join or nested-loop) is provided.
- Lift an artificial restriction that limited non-`GROUP BY` SQL to a single `SELECT` expression so standard SELECTs can return multiple columns/expressions.
- Keep `GROUP BY` semantics conservative by continuing to require a single select expression for aggregation fast-paths.

### Description
- Added an explicit error in `Parser::parse_query()` to reject `JOIN` tokens during AST generation with a clear message and source location. (`src/expression.cpp`)
- Reworked `QueryResult` to hold multiple projected columns and added accessors `column_count()`, `column_data()`, and `column_as<T>(idx)` while preserving single-column APIs. (`include/warpdb.hpp`)
- Extended the non-`GROUP BY` execution path in `execute_plan()` to support multi-expression projection by: adding `sort_rows_by_order()` for ORDER BY, applying LIMIT/OFFSET before projection, projecting each expression into a `ColumnData` vector, and returning a multi-column `QueryResult`; kept `DISTINCT` + multi-expression rejected. (`src/warpdb.cpp`)
- Tightened `plan_query()` to keep `GROUP BY` limited to one select expression and to select the appropriate execution kind for single-column fast paths. (`src/warpdb.cpp`)
- Removed the previous JOIN execution branch from `query_sql()` so JOIN handling consistently fails earlier in parsing; updated helper functions remain for future join implementation. (`src/warpdb.cpp`)
- Updated tests to reflect the new behavior: `sql_features_test` now asserts multi-column SELECT projection and retains the group-by guardrail, and `join_not_supported_test`, `query_parser_test`, and `optimizer_test` now verify that JOINs are rejected during AST generation. (tests/*)

### Testing
- Attempted `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`, which failed due to missing CUDA toolkit / `nvcc` in the environment (expected in CI with GPUs). (failed)
- Compiled and ran the parser-level test with `g++ -std=c++17 -Iinclude tests/query_parser_test.cpp src/expression.cpp -o /tmp/query_parser_test && /tmp/query_parser_test`, which executed successfully and confirmed JOIN rejection during parsing. (passed)
- Updated unit tests to match new semantics; full test-suite build/run could not be executed here because the environment lacks the CUDA toolchain. (not run)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7a709020883288e0ba8737b24ab32)