### PR TITLE
Fix setup.py to build CUDA JIT extension with nvcc

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from glob import glob
+import os
 from pathlib import Path
 from urllib.request import urlopen
 
@@ -40,7 +41,43 @@ class WarpDBBuildExt(build_ext):
         for ext in self.extensions:
             if include_dir not in ext.include_dirs:
                 ext.include_dirs.append(include_dir)
+
+        self._configure_cuda_compiler()
         super().build_extensions()
+
+    def _configure_cuda_compiler(self):
+        if not hasattr(self.compiler, 'compiler_so'):
+            return
+
+        if '.cu' not in self.compiler.src_extensions:
+            self.compiler.src_extensions.append('.cu')
+
+        default_compiler_so = self.compiler.compiler_so
+        super_compile = self.compiler._compile
+
+        def _compile(obj, src, ext, cc_args, extra_postargs, pp_opts):
+            is_cuda = os.path.splitext(src)[1] == '.cu'
+
+            if isinstance(extra_postargs, dict):
+                cxx_postargs = extra_postargs.get('cxx', [])
+                nvcc_postargs = extra_postargs.get('nvcc', [])
+            else:
+                cxx_postargs = extra_postargs
+                nvcc_postargs = extra_postargs
+
+            try:
+                if is_cuda:
+                    self.compiler.set_executable('compiler_so', os.environ.get('NVCC', 'nvcc'))
+                    postargs = ['-std=c++17', *nvcc_postargs]
+                else:
+                    postargs = cxx_postargs
+
+                super_compile(obj, src, ext, cc_args, postargs, pp_opts)
+            finally:
+                self.compiler.compiler_so = default_compiler_so
+
+        self.compiler._compile = _compile
+
 
 include_files = glob('include/*.hpp') + glob('include/*.h')
 data_files = ['data/test.csv', 'data/test.json', 'data/malformed.json']
@@ -54,12 +91,16 @@ ext_modules = [
             'src/csv_loader.cpp',
             'src/json_loader.cpp',
             'src/expression.cpp',
-            'src/jit.cpp',
+            'src/jit.cu',
             'src/multi_gpu_utils.cpp',
             'src/optimizer.cpp',
             'src/arrow_utils.cpp',
         ],
         include_dirs=['include'],
+        extra_compile_args={
+            'cxx': ['-O3'],
+            'nvcc': ['-O3', '--compiler-options', '-fPIC'],
+        },
         extra_link_args=['-lcudart', '-lnvrtc', '-lcuda'],
         cxx_std=17,
     )


### PR DESCRIPTION
### Motivation
- The Python extension listed a non-existent C++ source (`src/jit.cpp`) while the project and CMake use the CUDA source `src/jit.cu`, which would cause build failures. 
- `src/jit.cu` uses Thrust and CUDA headers and must be compiled by `nvcc` rather than the host C++ compiler. 
- The build helper needed to recognize `.cu` sources and route them to `nvcc` with appropriate flags to produce a working Python extension.

### Description
- Replaced the incorrect extension source entry `src/jit.cpp` with the actual CUDA file `src/jit.cu`. 
- Added `import os` and a `_configure_cuda_compiler` helper on `WarpDBBuildExt` that registers `.cu` in `compiler.src_extensions` and overrides the compiler `_compile` to use `nvcc` (or `$NVCC`) for `.cu` files while restoring the default compiler after each compile. 
- Added `extra_compile_args` to `Pybind11Extension` with separate `cxx` and `nvcc` lists so different flags can be passed for host C++ and CUDA compilation. 
- Kept existing behavior of injecting the downloaded `nlohmann/json.hpp` include directory into extension include paths via `WarpDBBuildExt.build_extensions`.

### Testing
- Ran `python -m py_compile setup.py` which succeeded and validated the updated `setup.py` is syntactically correct. 
- Attempted `python setup.py build_ext --inplace`, but the build could not be executed in this environment because `setuptools` is not installed here, so a full compile/run of the CUDA build was not completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e95121c1a88328aa8715b459fba20d)