### PR TITLE
Guard GPU JIT against unsupported string-column expressions

### DIFF
--- a/src/jit.cu
+++ b/src/jit.cu
@@ -292,6 +292,25 @@ void jit_compile_and_launch(const std::string &expr_code,
 
   int N = table.num_rows;
 
+  // String columns are uploaded as offsets + character buffers and cannot be
+  // used directly in generated arithmetic/boolean expressions. Detect string
+  // references early and fail with a clear error instead of allowing NVRTC
+  // compilation to fail with opaque diagnostics.
+  auto references_column = [](const std::string &code,
+                              const std::string &column_name) {
+    if (code.empty()) return false;
+    const std::string token = column_name + "[idx]";
+    return code.find(token) != std::string::npos;
+  };
+  for (const auto &c : table.columns) {
+    if (c.type != DataType::String) continue;
+    if (references_column(expr_code, c.name) ||
+        references_column(condition_code, c.name)) {
+      throw std::runtime_error(
+          "String columns are not supported in GPU JIT expressions: " + c.name);
+    }
+  }
+
   std::string body;
   if (!condition_code.empty()) {
     body = "if (" + condition_code + ") {\n    output[idx] = " + expr_code +

--- a/tests/string_column_query_test.cpp
+++ b/tests/string_column_query_test.cpp
@@ -69,5 +69,15 @@ int main() {
     assert(std::abs(res[1] - (20.5f + 3)) < 1e-5);
     assert(std::abs(res[2] - (30.25f + 7)) < 1e-5);
 
+    bool threw_on_string_expr = false;
+    try {
+        (void)db.query("name");
+    } catch (const std::runtime_error& e) {
+        threw_on_string_expr =
+            std::string(e.what()).find("String columns are not supported in GPU JIT expressions") !=
+            std::string::npos;
+    }
+    assert(threw_on_string_expr && "Expected query using string column to throw");
+
     return 0;
 }


### PR DESCRIPTION
### Motivation
- Prevent undefined behavior and opaque NVRTC/kernel failures when `DataType::String` columns are referenced in generated CUDA expressions, since strings are represented as offsets/char buffers and `cuda_type()` currently maps `String` to `void*` (unsupported). 

### Description
- Added an early validation in `jit_compile_and_launch` that scans the generated expression and WHERE condition for references of the form ``<column_name>[idx]`` and throws a clear `std::runtime_error` when a `DataType::String` column is referenced. 
- The check is implemented in `src/jit.cu` and raises `"String columns are not supported in GPU JIT expressions: <col>"` to avoid attempting NVRTC compilation for unsupported cases. 
- Updated `tests/string_column_query_test.cpp` to assert that numeric-only queries still succeed and that a direct query referencing a string column now throws the expected error. 
- Only runtime validation was added; non-string columns and codepath for parameter/param generation remain unchanged.

### Testing
- Attempted to configure the project with `cmake -S . -B build`, but the environment lacks the CUDA toolkit (`nvcc`) so the build/config step failed with a missing-nvcc error. 
- No GPU kernel compilation or test binary execution was run in this environment due to the missing CUDA toolchain, so the added test was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9512fc004832895f7c2f2d57a7307)