### PR TITLE
Use per-thread CUDA stream for JIT Thrust group operations

### DIFF
--- a/src/jit.cu
+++ b/src/jit.cu
@@ -456,11 +456,12 @@ void jit_group_sum(const std::string &val_expr_code,
   int *tmp_keys_ptr = tmp_keys.get();
   std::vector<void *> args{&d_price, &d_quantity, &tmp_vals_ptr,
                            &tmp_keys_ptr, &N};
-  CU_CHECK(cuLaunchKernel(kernel_func, blocks, 1, 1, threads, 1, 1, 0, 0,
+  CU_CHECK(cuLaunchKernel(kernel_func, blocks, 1, 1, threads, 1, 1, 0,
+                          reinterpret_cast<CUstream>(cudaStreamPerThread),
                           args.data(), nullptr));
   CU_CHECK(cuCtxSynchronize());
 
-  auto exec_policy = thrust::cuda::par.on(0);
+  auto exec_policy = thrust::cuda::par.on(cudaStreamPerThread);
   auto tmp_keys_begin = thrust::device_pointer_cast(tmp_keys.get());
   auto tmp_vals_begin = thrust::device_pointer_cast(tmp_vals.get());
   thrust::sort_by_key(exec_policy, tmp_keys_begin, tmp_keys_begin + N,
@@ -493,7 +494,7 @@ template <typename KeyT, typename ValueT, typename ReduceOp>
 int jit_group_reduce_impl(const void *d_keys_raw, const void *d_values_raw,
                           int64_t *d_out_keys, float *d_out_vals, int N,
                           ReduceOp reduce_op) {
-  auto exec_policy = thrust::cuda::par.on(0);
+  auto exec_policy = thrust::cuda::par.on(cudaStreamPerThread);
   const auto *d_keys = static_cast<const KeyT *>(d_keys_raw);
   const auto *d_values = static_cast<const ValueT *>(d_values_raw);
 
@@ -525,7 +526,7 @@ int jit_group_reduce_impl(const void *d_keys_raw, const void *d_values_raw,
 template <typename KeyT>
 int jit_group_count_impl(const void *d_keys_raw, int64_t *d_out_keys,
                          float *d_out_counts, int N) {
-  auto exec_policy = thrust::cuda::par.on(0);
+  auto exec_policy = thrust::cuda::par.on(cudaStreamPerThread);
   const auto *d_keys = static_cast<const KeyT *>(d_keys_raw);
 
   DeviceBuffer<KeyT> tmp_keys(static_cast<size_t>(N));


### PR DESCRIPTION
### Motivation
- Thrust calls and the JIT kernel were pinned to stream 0 which couples to the default stream and can serialize otherwise independent GPU work, reducing concurrency for asynchronous queries.

### Description
- Replaced hardcoded `thrust::cuda::par.on(0)` with `thrust::cuda::par.on(cudaStreamPerThread)` in `src/jit.cu` to bind Thrust ops to the per-thread stream.
- Updated the JIT kernel launch to pass `reinterpret_cast<CUstream>(cudaStreamPerThread)` instead of stream `0`, aligning the custom kernel launch with Thrust's per-thread stream.
- Changes affect the JIT group operator paths (`jit_group_sum`, `jit_group_reduce_impl`, `jit_group_count_impl`) in `src/jit.cu`.

### Testing
- Attempted to configure and build the project with CMake (`cmake -S . -B build -DWARPDB_BUILD_PYTHON=OFF && cmake --build build -j2`) but the run failed because the CUDA toolkit (`nvcc`) is not available in the environment, so no binary tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea0d1c050c83288d8282d6319b38f8)