### PR TITLE
Treat SQL '=' as equality in generated CUDA expressions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,14 @@ add_executable(tokenizer_tests
 add_test(NAME tokenizer_tests COMMAND tokenizer_tests)
 
 
+add_executable(equals_operator_test
+    tests/equals_operator_test.cpp
+    src/expression.cpp
+)
+
+add_test(NAME equals_operator_test COMMAND equals_operator_test)
+
+
 add_executable(sql_features_test
     tests/sql_features_test.cpp
 )

--- a/README.md
+++ b/README.md
@@ -274,6 +274,8 @@ WarpDB implements a simple recursive descent parser to transform SQL-like expres
 - Comparison operations (`>`, `<`, `>=`, `<=`, `==`, `!=`)
   - The tokenizer checks two-character operators (e.g., `>=`, `<=`) before
     handling single-character ones.
+  - A single `=` is also accepted and treated as equality (equivalent to `==`),
+    matching SQL syntax such as `WHERE price = 10` and `JOIN ... ON a.id = b.id`.
 - Parenthesized expressions
 
 ### JIT Compilation

--- a/src/expression.cpp
+++ b/src/expression.cpp
@@ -248,6 +248,10 @@ ASTNodePtr Parser::parse_comparison() {
   while (match(">") || match("<") || match(">=") || match("<=") ||
          match("==") || match("!=") || match("=")) {
     std::string op = toks[current - 1].value;
+    // SQL uses a single '=' for equality. Normalize it to '==' so generated
+    // CUDA expressions perform a comparison instead of an assignment.
+    if (op == "=")
+      op = "==";
     ASTNodePtr right = parse_expression_internal();
     node =
         std::make_unique<BinaryOpNode>(op, std::move(node), std::move(right));

--- a/tests/equals_operator_test.cpp
+++ b/tests/equals_operator_test.cpp
@@ -1,0 +1,31 @@
+#include "expression.hpp"
+#include <cassert>
+#include <iostream>
+#include <string>
+
+// SQL uses a single '=' for equality. Verify that it is normalized so the
+// generated CUDA expression performs a comparison ('==') rather than an
+// assignment ('='), which would both always evaluate truthy and corrupt the
+// column data on the device.
+static std::string cuda_for(const std::string &expr) {
+  auto tokens = tokenize(expr);
+  auto ast = parse_expression(tokens);
+  return ast->to_cuda_expr();
+}
+
+int main() {
+  std::string single = cuda_for("price = 10");
+  std::string doubled = cuda_for("price == 10");
+  assert(single == doubled &&
+         "single '=' should generate the same CUDA as '=='");
+  assert(single.find("==") != std::string::npos &&
+         "expected an equality comparison in generated CUDA");
+
+  // A parenthesized/compound predicate must not contain a lone '=' either.
+  std::string compound = cuda_for("price = 10 AND quantity = 2");
+  assert(compound.find(" = ") == std::string::npos &&
+         "generated CUDA must not contain an assignment operator");
+
+  std::cout << "equals operator test passed\n";
+  return 0;
+}


### PR DESCRIPTION
## Problem

The expression parser accepts a single `=` as a comparison operator (`parse_comparison` matches `"="`), but it kept the raw token on the `BinaryOpNode`. `BinaryOpNode::to_cuda_expr()` then emitted a bare `=` into the JIT-compiled CUDA kernel.

In generated CUDA, `(price[idx] = 10.0f)` is an **assignment**, not a comparison:
- it always evaluates truthy (the assigned value `10.0f != 0`), so every row passes the predicate, and
- it **overwrites the column data on the device**.

This is reachable through the GPU expression path (`WarpDB::query` / `query_multi_gpu`), e.g. `db.query("price WHERE price = 10")`.

## Fix

Normalize `=` to `==` when building the comparison node in `parse_comparison`. The host-side evaluators (`eval_node`, `eval_having_node`) and the JOIN-condition detection already accept both `=` and `==`, so this only corrects the GPU codegen path and leaves the AST canonical.

## Testing

- Added `tests/equals_operator_test.cpp` (parser-only, no GPU required): asserts `price = 10` generates the same CUDA as `price == 10`, contains `==`, and that a compound predicate contains no lone `=`.
- Verified the existing parser test suite (`tokenizer_tests`, `parsing_error_tests`, `precedence_tests`, `query_parser_test`, `expression_test`) still passes.
- Updated the README to document that `=` is accepted as equality.

Note: this environment has no CUDA toolkit, so the GPU/JIT execution path was not built here; the change is verified through the pure-C++ parser layer, and the generated-CUDA string is asserted directly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJEwghgGPiVnTCMiYqtYt5)_