### PR TITLE
Support aggregate functions inside HAVING clauses

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,14 @@ add_executable(tokenizer_tests
 add_test(NAME tokenizer_tests COMMAND tokenizer_tests)
 
 
+add_executable(having_aggregate_test
+    tests/having_aggregate_test.cpp
+    src/expression.cpp
+)
+
+add_test(NAME having_aggregate_test COMMAND having_aggregate_test)
+
+
 add_executable(sql_features_test
     tests/sql_features_test.cpp
 )

--- a/README.md
+++ b/README.md
@@ -194,6 +194,8 @@ arrow_arr = pa.Array._import_from_c(arr_capsule, schema_capsule)
 
 # Use the SQL helper for GROUP BY
 ./warpdb "SELECT SUM(price) FROM test GROUP BY quantity"
+# Filter groups by an aggregate with HAVING
+./warpdb "SELECT SUM(price) FROM test GROUP BY quantity HAVING SUM(price) > 20"
 # Limit results after sorting
 ./warpdb "SELECT price FROM test ORDER BY price DESC LIMIT 5"
 

--- a/src/expression.cpp
+++ b/src/expression.cpp
@@ -303,6 +303,31 @@ ASTNodePtr Parser::parse_factor() {
   if (tok.type == TokenType::Number) {
     advance();
     return std::make_unique<ConstantNode>(tok.value);
+  } else if (tok.type == TokenType::Keyword &&
+             (tok.value == "SUM" || tok.value == "AVG" ||
+              tok.value == "COUNT" || tok.value == "MIN" ||
+              tok.value == "MAX")) {
+    // Aggregate functions may appear in expression contexts such as HAVING
+    // (e.g. "HAVING SUM(price) > 10"). The SELECT list has its own aggregate
+    // handling; here we support them anywhere an expression is parsed so that
+    // the host-side aggregate evaluator can filter groups by their aggregates.
+    std::string kw = tok.value;
+    advance();
+    if (!match("("))
+      throw std::runtime_error("Expected '(' after " + kw + " aggregation");
+    ASTNodePtr inner = parse_expression_internal();
+    if (!match(")"))
+      throw std::runtime_error("Expected ')' after " + kw + " argument");
+    AggregationType at = AggregationType::Sum;
+    if (kw == "AVG")
+      at = AggregationType::Avg;
+    else if (kw == "COUNT")
+      at = AggregationType::Count;
+    else if (kw == "MIN")
+      at = AggregationType::Min;
+    else if (kw == "MAX")
+      at = AggregationType::Max;
+    return std::make_unique<AggregationNode>(at, std::move(inner));
   } else if (tok.type == TokenType::Identifier) {
     std::string ident = tok.value;
     advance();

--- a/tests/having_aggregate_test.cpp
+++ b/tests/having_aggregate_test.cpp
@@ -1,0 +1,35 @@
+#include "expression.hpp"
+#include <cassert>
+#include <iostream>
+#include <string>
+
+// HAVING clauses are documented as supported, and filtering groups by an
+// aggregate is their primary purpose. The host-side evaluator already handles
+// AggregationNode inside HAVING; this verifies the parser produces one so
+// queries like "HAVING SUM(price) > 10" parse instead of throwing.
+static QueryAST parse(const std::string &sql) {
+  return parse_query(tokenize(sql));
+}
+
+int main() {
+  QueryAST q = parse(
+      "SELECT SUM(price) FROM test GROUP BY quantity HAVING SUM(price) > 10");
+  assert(q.having.has_value() && "expected a HAVING clause");
+
+  auto *cmp = dynamic_cast<const BinaryOpNode *>(q.having->get());
+  assert(cmp && cmp->op == ">" && "HAVING should be a comparison");
+  auto *agg = dynamic_cast<const AggregationNode *>(cmp->left.get());
+  assert(agg && agg->agg == AggregationType::Sum &&
+         "left side of HAVING should be a SUM aggregation");
+
+  // Other aggregates and compound predicates should parse as well.
+  QueryAST q2 = parse(
+      "SELECT AVG(price) FROM test GROUP BY quantity "
+      "HAVING AVG(price) > 5 AND COUNT(price) > 1");
+  assert(q2.having.has_value());
+  auto *root = dynamic_cast<const BinaryOpNode *>(q2.having->get());
+  assert(root && root->op == "&&" && "expected AND-combined HAVING predicate");
+
+  std::cout << "having aggregate test passed\n";
+  return 0;
+}


### PR DESCRIPTION
## Problem

`HAVING` is listed as a supported SQL feature, and the host-side group evaluator (`eval_having_node` in `src/warpdb.cpp`) already interprets an `AggregationNode` against each group's aggregate data (SUM/AVG/COUNT/MIN/MAX). But the canonical HAVING form — filtering groups by an aggregate — failed to parse:

```
SELECT SUM(price) FROM test GROUP BY quantity HAVING SUM(price) > 10
  -> Failed to parse SQL: Unexpected token (Keyword: SUM)
```

Only the SELECT-list parser (`parse_select_item`) recognized aggregate keywords. The generic expression parser used for the HAVING clause treated `SUM`/`AVG`/`COUNT`/`MIN`/`MAX` as unexpected keywords, so only non-aggregate predicates like `HAVING price > 10` worked.

## Fix

Teach `parse_factor` to accept an aggregate keyword followed by a parenthesized argument and build an `AggregationNode`. Aggregates now parse anywhere an expression is accepted, which is exactly what the existing `eval_having_node` needs. No execution changes were required — the evaluator was already ready.

The SELECT-list path keeps its own handling (including window `OVER (...)`), so it is unaffected.

## Testing

- Added `tests/having_aggregate_test.cpp` (parser-only, no GPU required): verifies `HAVING SUM(price) > 10` produces a comparison whose left operand is a `Sum` `AggregationNode`, and that compound predicates like `HAVING AVG(price) > 5 AND COUNT(price) > 1` parse.
- Confirmed SELECT-list aggregates, window `OVER`, multi-column projection, and combined `HAVING ... ORDER BY ... LIMIT` still parse.
- Existing parser test suite still passes.
- Added a README example.

Note: this environment has no CUDA toolkit, so the GPU-backed execution was not built here; verification is at the parser layer, and the group/HAVING evaluator that consumes the new node already existed unchanged in `src/warpdb.cpp`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJEwghgGPiVnTCMiYqtYt5)_