### PR TITLE
Add a GPU-free host test lane for parser/codegen tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,16 @@ on:
   pull_request:
 
 jobs:
+  host-tests:
+    # Fast, GPU-free lane that builds and runs the parser/host tests directly
+    # with g++. Catches SQL tokenizer/parser and codegen regressions without
+    # needing the CUDA toolkit.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run host-only parser tests
+        run: ./tests/run_host_tests.sh
+
   build:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -92,6 +92,15 @@ bindings are skipped.
 Run `ctest` from the `build` directory to execute the project's tests. Some
 tests rely on CUDA and optional libraries like Arrow or pybind11.
 
+The parser and code-generation tests depend only on the host C++ sources and
+can be run without a CUDA toolkit or GPU:
+
+```bash
+./tests/run_host_tests.sh
+```
+
+CI runs this GPU-free lane on every change in addition to the full build.
+
 ## Usage
 
 ```bash

--- a/tests/run_host_tests.sh
+++ b/tests/run_host_tests.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# Compile and run the WarpDB tests that depend only on the host C++ sources
+# (the SQL tokenizer/parser in src/expression.cpp). These need neither a CUDA
+# toolkit nor a GPU, so they give CI a fast lane that catches parser and
+# code-generation regressions even on machines without nvcc.
+#
+# The main CMake/ctest build still exercises the full GPU-backed suite; this is
+# an additive safety net, not a replacement.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+CXX=${CXX:-g++}
+STD=${STD:-c++17}
+
+# Tests whose only translation-unit dependency is src/expression.cpp. Keep this
+# list in sync when adding new parser-only tests.
+host_tests=(
+  tests/test_expression.cpp
+  tests/tokenizer_tests.cpp
+  tests/parsing_error_tests.cpp
+  tests/precedence_tests.cpp
+  tests/query_parser_test.cpp
+  tests/equals_operator_test.cpp
+  tests/having_aggregate_test.cpp
+)
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+fail=0
+for src in "${host_tests[@]}"; do
+  name="$(basename "$src" .cpp)"
+  if ! "$CXX" "-std=$STD" -Iinclude "$src" src/expression.cpp -o "$tmp/$name" 2>"$tmp/$name.log"; then
+    echo "FAIL  $name (compile)"
+    cat "$tmp/$name.log"
+    fail=1
+    continue
+  fi
+  if out="$("$tmp/$name" 2>&1)"; then
+    echo "PASS  $name -- $out"
+  else
+    echo "FAIL  $name (run)"
+    echo "$out"
+    fail=1
+  fi
+done
+
+if [ "$fail" -ne 0 ]; then
+  echo "Host-only test suite FAILED"
+  exit 1
+fi
+echo "Host-only test suite passed (${#host_tests[@]} tests)"


### PR DESCRIPTION
## Motivation

The SQL tokenizer, parser, and expression code generation (`src/expression.cpp`) are pure host C++, but the only way to run their tests was the full `ctest` build, which requires the CUDA toolkit (`find_package(CUDAToolkit REQUIRED)`, `project(... CUDA)`). Environments without `nvcc` couldn't catch parser regressions at all — which is exactly how the recent `=`-codegen and HAVING-aggregate defects went unnoticed.

## Change

- **`tests/run_host_tests.sh`** — compiles and runs the parser-only tests directly with `g++` (no CUDA, no GPU). It builds each test against `src/expression.cpp` and fails if any fails to compile or run.
- **CI** — a new `host-tests` job runs this script on every push/PR, in parallel with the existing full `build` job. It needs no CUDA install, so it's fast.
- **README** — documents the lane.

The full GPU-backed `ctest` suite is unchanged; this is an additive safety net.

## Testing

```
$ ./tests/run_host_tests.sh
PASS  test_expression -- All parser tests passed
PASS  tokenizer_tests -- All tokenizer tests passed
PASS  parsing_error_tests -- All regression tests passed
PASS  precedence_tests -- All precedence tests passed
PASS  query_parser_test -- Query parse test passed
PASS  equals_operator_test -- equals operator test passed
PASS  having_aggregate_test -- having aggregate test passed
Host-only test suite passed (7 tests)
```

Note: the list of host-only tests is maintained explicitly in the script; new parser-only tests should be added there.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJEwghgGPiVnTCMiYqtYt5)_