### PR TITLE
Accept SQL '<>' as the not-equal operator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,14 @@ add_executable(equals_operator_test
 add_test(NAME equals_operator_test COMMAND equals_operator_test)
 
 
+add_executable(not_equal_operator_test
+    tests/not_equal_operator_test.cpp
+    src/expression.cpp
+)
+
+add_test(NAME not_equal_operator_test COMMAND not_equal_operator_test)
+
+
 add_executable(sql_features_test
     tests/sql_features_test.cpp
 )

--- a/README.md
+++ b/README.md
@@ -278,6 +278,8 @@ WarpDB implements a simple recursive descent parser to transform SQL-like expres
     handling single-character ones.
   - A single `=` is also accepted and treated as equality (equivalent to `==`),
     matching SQL syntax such as `WHERE price = 10` and `JOIN ... ON a.id = b.id`.
+  - SQL's `<>` is accepted as not-equal (equivalent to `!=`), e.g.
+    `WHERE price <> 10`.
 - Parenthesized expressions
 
 ### JIT Compilation

--- a/src/expression.cpp
+++ b/src/expression.cpp
@@ -127,6 +127,17 @@ std::vector<Token> tokenize(const std::string &input) {
       // Handle two-character comparison operators (>=, <=, ==, !=) first
       int start_col = column;
       int start_line = line;
+      // SQL's '<>' is the not-equal operator; normalize it to '!=' so the rest
+      // of the pipeline (parser, host evaluator, CUDA codegen) treats it
+      // uniformly.
+      if (input[i] == '<' && i + 1 < input.size() && input[i + 1] == '>') {
+        advance_char(input[i]);
+        i++;
+        advance_char(input[i]);
+        i++;
+        tokens.push_back({TokenType::Operator, "!=", start_line, start_col});
+        continue;
+      }
       std::string op(1, input[i]);
       if (i + 1 < input.size() && input[i + 1] == '=') {
         op += '=';

--- a/tests/not_equal_operator_test.cpp
+++ b/tests/not_equal_operator_test.cpp
@@ -1,0 +1,31 @@
+#include "expression.hpp"
+#include <cassert>
+#include <iostream>
+#include <string>
+
+// SQL's '<>' is the not-equal operator. Verify the tokenizer normalizes it to
+// '!=' and that it generates the same CUDA as '!=' (and never a stray '<' '>'
+// pair, which would parse as two separate comparisons).
+static std::string cuda_for(const std::string &expr) {
+  return parse_expression(tokenize(expr))->to_cuda_expr();
+}
+
+int main() {
+  auto toks = tokenize("price <> 10");
+  // Expect: Identifier, Operator '!=', Number, End
+  assert(toks.size() == 4);
+  assert(toks[1].type == TokenType::Operator && toks[1].value == "!=" &&
+         "'<>' should tokenize as a single '!=' operator");
+
+  std::string diamond = cuda_for("price <> 10");
+  std::string bang = cuda_for("price != 10");
+  assert(diamond == bang && "'<>' should generate the same CUDA as '!='");
+  assert(diamond.find("!=") != std::string::npos);
+
+  // Works inside a compound predicate too.
+  auto q = parse_query(tokenize("SELECT price FROM t WHERE price <> 10"));
+  assert(q.where.has_value());
+
+  std::cout << "not-equal operator test passed\n";
+  return 0;
+}


### PR DESCRIPTION
## Problem

The tokenizer recognized `!=` for inequality but not the equally standard SQL `<>`. Input like `WHERE price <> 10` was tokenized as two separate operators (`<` then `>`), producing a confusing parse error rather than a not-equal comparison.

## Fix

Recognize `<>` in the tokenizer's comparison-operator branch and emit a single canonical `!=` operator token. The parser, host-side evaluator, and CUDA codegen already handle `!=`, so no downstream changes are needed — same pattern as the recent `=` → `==` normalization.

## Testing

- Added `tests/not_equal_operator_test.cpp` (parser-only): asserts `price <> 10` tokenizes to a single `!=`, generates the same CUDA as `price != 10`, and parses inside a `WHERE` clause.
- Existing parser suite still passes.
- Documented the operator in the README.

Note (test wiring): registered as a ctest target. The GPU-free host lane added in #166 keeps an explicit test list; once that merges I'll add `not_equal_operator_test` to it (or switch it to auto-discovery) so the two stay in sync.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJEwghgGPiVnTCMiYqtYt5)_