### PR TITLE
Evaluate AND/OR in the host-side expression interpreter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,14 @@ add_executable(equals_operator_test
 add_test(NAME equals_operator_test COMMAND equals_operator_test)
 
 
+add_executable(eval_logical_ops_test
+    tests/eval_logical_ops_test.cpp
+    src/expression.cpp
+)
+
+add_test(NAME eval_logical_ops_test COMMAND eval_logical_ops_test)
+
+
 add_executable(sql_features_test
     tests/sql_features_test.cpp
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,10 @@ add_executable(eval_logical_ops_test
     tests/eval_logical_ops_test.cpp
     src/expression.cpp
 )
+# eval_helpers.hpp pulls in cuda_utils.hpp/<cuda_runtime.h> transitively. This
+# test exercises only host logic, so use the lightweight CUDA stub headers
+# instead of requiring the real toolkit include path for this CXX target.
+target_include_directories(eval_logical_ops_test PRIVATE tests/stubs)
 
 add_test(NAME eval_logical_ops_test COMMAND eval_logical_ops_test)
 

--- a/include/eval_helpers.hpp
+++ b/include/eval_helpers.hpp
@@ -36,6 +36,8 @@ float eval_node(const ASTNode *node, const Context &ctx, int idx) {
         if (op == "-") return l - r;
         if (op == "*") return l * r;
         if (op == "/") return l / r;
+        if (op == "&&") return (l != 0.0f) && (r != 0.0f);
+        if (op == "||") return (l != 0.0f) || (r != 0.0f);
         if (op == ">") return l > r;
         if (op == "<") return l < r;
         if (op == ">=") return l >= r;

--- a/tests/eval_logical_ops_test.cpp
+++ b/tests/eval_logical_ops_test.cpp
@@ -1,0 +1,37 @@
+#include "expression.hpp"
+#include "eval_helpers.hpp"
+#include <cassert>
+#include <iostream>
+#include <vector>
+
+// The host-side interpreter (eval_helpers.hpp) drives WHERE filtering, ORDER BY
+// keys, and non-column SELECT expressions in query_sql. It must evaluate the
+// logical operators produced by AND/OR; otherwise a predicate like
+// "price > 10 AND qty < 5" collapses to 0 and filters out every row.
+static int count_passing(const std::string &predicate, const HostTable &t) {
+  auto ast = parse_expression(tokenize(predicate));
+  int n = 0;
+  for (int i = 0; i < t.num_rows(); ++i)
+    if (eval_condition(ast.get(), t, i))
+      ++n;
+  return n;
+}
+
+int main() {
+  HostTable t;
+  t.columns.push_back({"price", DataType::Float32,
+                       std::vector<float>{5.0f, 20.0f, 30.0f}});
+  t.columns.push_back({"qty", DataType::Int32, std::vector<int32_t>{1, 4, 2}});
+
+  // rows: (5,1) (20,4) (30,2)
+  assert(count_passing("price > 10 AND qty < 5", t) == 2); // (20,4),(30,2)
+  assert(count_passing("price > 25 OR qty < 2", t) == 2);  // (5,1),(30,2)
+  assert(count_passing("price > 10 AND qty < 3", t) == 1); // (30,2)
+  assert(count_passing("price > 100 OR qty > 100", t) == 0);
+
+  // Sanity: a bare comparison still works.
+  assert(count_passing("price > 10", t) == 2);
+
+  std::cout << "eval logical ops test passed\n";
+  return 0;
+}


### PR DESCRIPTION
## Problem (silent wrong results)

The templated `eval_node` in `include/eval_helpers.hpp` is the host-side interpreter that drives, in the `query_sql` path:
- **WHERE filtering** (`eval_condition` → `filter_rows`),
- **ORDER BY** sort keys, and
- non-column **SELECT expressions**.

It handled arithmetic and comparison operators but **not** the `&&`/`||` nodes the parser produces for SQL `AND`/`OR`. A `BinaryOpNode` with op `&&` or `||` fell through every branch to the default `return 0.0f`.

Consequence: a perfectly valid query such as

```
SELECT price FROM test WHERE price > 10 AND quantity < 5
```

evaluated its predicate to `0` for **every** row and returned an empty result — no error, just wrong output. This is the CLI's primary path (`./warpdb "<sql>"`).

The JOIN evaluator (`eval_join_node`) and the HAVING evaluator (`eval_having_node`) already handled `&&`/`||`; only this interpreter was missing them, so the two paths silently disagreed.

## Fix

Add the two logical operators to `eval_node`, matching the semantics already used by the other evaluators:

```cpp
if (op == "&&") return (l != 0.0f) && (r != 0.0f);
if (op == "||") return (l != 0.0f) || (r != 0.0f);
```

## Testing

Added `tests/eval_logical_ops_test.cpp` — a host-only test (links `src/expression.cpp`) that filters a small in-memory `HostTable` with `AND`/`OR` predicates and asserts the passing-row counts. It fails before this change (0 rows pass) and passes after. Reproduced and verified locally:

```
eval logical ops test passed
```

Note: the fix lives in a pure-C++ header, so it is fully exercised without a GPU. The bug affected only the host `query_sql` interpreter; the GPU JIT path already emits correct `&&`/`||` into generated CUDA.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJEwghgGPiVnTCMiYqtYt5)_