### PR TITLE
Support SELECT * to project all columns

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,14 @@ add_executable(equals_operator_test
 add_test(NAME equals_operator_test COMMAND equals_operator_test)
 
 
+add_executable(select_star_test
+    tests/select_star_test.cpp
+    src/expression.cpp
+)
+
+add_test(NAME select_star_test COMMAND select_star_test)
+
+
 add_executable(sql_features_test
     tests/sql_features_test.cpp
 )

--- a/README.md
+++ b/README.md
@@ -203,6 +203,10 @@ arrow_arr = pa.Array._import_from_c(arr_capsule, schema_capsule)
 # selected columns in order:
 ./warpdb "SELECT price, quantity FROM test"
 
+# SELECT * expands to every column of the table, in schema order
+# (not supported together with JOIN):
+./warpdb "SELECT * FROM test WHERE price > 10"
+
 # Note: GROUP BY queries still support only a single SELECT expression.
 ```
 

--- a/include/expression.hpp
+++ b/include/expression.hpp
@@ -148,6 +148,9 @@ struct GroupByClause {
 
 struct QueryAST {
   std::vector<ASTNodePtr> select_list;
+  // Set when the SELECT list is a single '*'. The select_list is left empty and
+  // expanded to every column of the source table at execution time.
+  bool select_all = false;
   std::string from_table;
   std::vector<JoinClause> joins;
   std::optional<ASTNodePtr> where;

--- a/src/expression.cpp
+++ b/src/expression.cpp
@@ -450,7 +450,22 @@ QueryAST Parser::parse_query() {
         break;
       item.push_back(toks[current++]);
     }
-    query.select_list.push_back(parse_select_item(item));
+    // A lone '*' selects every column. It is only valid as the sole select
+    // item; combined forms like "SELECT *, price" are rejected.
+    if (item.size() == 1 && item[0].type == TokenType::Operator &&
+        item[0].value == "*") {
+      if (query.select_all || !query.select_list.empty()) {
+        throw std::runtime_error(
+            "'*' must be the only expression in the SELECT list");
+      }
+      query.select_all = true;
+    } else {
+      if (query.select_all) {
+        throw std::runtime_error(
+            "'*' must be the only expression in the SELECT list");
+      }
+      query.select_list.push_back(parse_select_item(item));
+    }
     if (current < end && toks[current].type == TokenType::Operator &&
         toks[current].value == ",")
       current++; // skip comma

--- a/src/warpdb.cpp
+++ b/src/warpdb.cpp
@@ -970,6 +970,23 @@ QueryResult WarpDB::query_sql(const std::string &sql) {
         throw std::runtime_error(std::string("Failed to parse SQL: ") + e.what());
     }
 
+    // Expand "SELECT *" into an explicit column list, preserving the table's
+    // column order, before planning. JOIN expansion (which would need
+    // relation-qualified names) is not supported yet.
+    if (ast.select_all) {
+        if (!ast.joins.empty()) {
+            throw std::runtime_error("SELECT * is not supported with JOIN yet");
+        }
+        if (table_.columns.empty()) {
+            throw std::runtime_error("SELECT * requires at least one column");
+        }
+        ast.select_list.clear();
+        for (const auto &c : table_.columns) {
+            ast.select_list.push_back(std::make_unique<VariableNode>(c.name));
+        }
+        ast.select_all = false;
+    }
+
     std::unordered_set<std::string> cols;
     for (const auto &c : table_.columns) cols.insert(c.name);
 

--- a/tests/select_star_test.cpp
+++ b/tests/select_star_test.cpp
@@ -1,0 +1,47 @@
+#include "expression.hpp"
+#include <cassert>
+#include <iostream>
+#include <string>
+
+// "SELECT *" is parsed by setting QueryAST::select_all and leaving the
+// select_list empty; query_sql expands it into one VariableNode per table
+// column at execution time. The parser only accepts '*' as the sole item.
+static QueryAST parse(const std::string &sql) {
+  return parse_query(tokenize(sql));
+}
+
+static bool throws(const std::string &sql) {
+  try {
+    parse(sql);
+    return false;
+  } catch (const std::exception &) {
+    return true;
+  }
+}
+
+int main() {
+  QueryAST q = parse("SELECT * FROM test");
+  assert(q.select_all && "expected select_all to be set");
+  assert(q.select_list.empty() && "select_list stays empty for '*'");
+  assert(q.from_table == "test");
+
+  // '*' combines with the rest of the clauses.
+  QueryAST q2 = parse("SELECT * FROM test WHERE price > 10 ORDER BY price LIMIT 2");
+  assert(q2.select_all && q2.where.has_value() && q2.order_by.has_value() &&
+         q2.limit.has_value());
+
+  // A normal projection is unaffected (no select_all).
+  QueryAST q3 = parse("SELECT price, quantity FROM test");
+  assert(!q3.select_all && q3.select_list.size() == 2);
+
+  // '*' must be alone: mixed forms are rejected.
+  assert(throws("SELECT *, price FROM test"));
+  assert(throws("SELECT price, * FROM test"));
+
+  // Multiplication is still multiplication.
+  QueryAST q4 = parse("SELECT price * quantity FROM test");
+  assert(!q4.select_all && q4.select_list.size() == 1);
+
+  std::cout << "select star test passed\n";
+  return 0;
+}


### PR DESCRIPTION
## What

Adds `SELECT *` to the SQL surface.

- **Parser**: a lone `*` as the SELECT list sets a new `QueryAST::select_all` flag and leaves `select_list` empty. Mixed forms (`SELECT *, price`) are rejected with a clear error; `price * quantity` is still multiplication.
- **Execution**: `query_sql` expands `select_all` into one `VariableNode` per source-table column, **in schema order**, before planning. This reuses the existing, already-tested multi-column projection path rather than adding a new execution mode.

## Scope / safety

Expansion is for the single-table path only. `SELECT *` with a `JOIN` would need relation-qualified column names, so it throws `SELECT * is not supported with JOIN yet` rather than guessing. Empty schema throws a clear error.

## Testing

- Added `tests/select_star_test.cpp` (parser-only): verifies `select_all` is set with an empty list, that `*` composes with WHERE/ORDER BY/LIMIT, that normal projections are unaffected, that mixed `*` forms are rejected, and that `price * quantity` still parses as multiplication.
- Existing parser suite still passes.
- README example added.

Note: the parser behavior is verified locally without a GPU. The runtime expansion is straightforward host code that feeds the existing projection path exercised by `SELECT a, b`; the full projection runs under the GPU-backed `ctest` suite in CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJEwghgGPiVnTCMiYqtYt5)_