### PR TITLE
Fix build: remove stray namespace-closing brace in warpdb.cpp

### DIFF
--- a/src/warpdb.cpp
+++ b/src/warpdb.cpp
@@ -736,8 +736,6 @@ float eval_join_node(const ASTNode *node, const HostTable &table, int left_idx,
     return 0.0f;
 }
 
-} // namespace
-
 QueryPlan plan_query(QueryAST &&ast, const std::unordered_set<std::string> &cols, const Table &table) {
     validate_query_ast(ast, cols);
 


### PR DESCRIPTION
## The project does not compile

CI's `build` job has failed on **every** run — including `main` pushes for the last several merged PRs. The root cause is a stray brace in `src/warpdb.cpp`:

The anonymous namespace that wraps the `query_sql` helpers is **closed twice**:
- once at the end of `eval_join_node` (`} // namespace`), which terminated the namespace early and left `plan_query`/`execute_plan` at global scope, and
- again after `execute_plan`, where `} // namespace` closes a namespace that is no longer open.

Since `warpdb.cpp` is compiled with `nvcc` (it's marked `LANGUAGE CUDA`), this shows up as:

```
src/warpdb.cpp(962): error: expected a declaration
src/warpdb.cpp(1014): error: identifier "cond_ast" is undefined
src/warpdb.cpp(1052): error: variable "validate_ast" has already been defined
... 17 errors detected in the compilation of "src/warpdb.cpp"
```

— the second brace, then a cascade of bogus "already defined"/"expected a declaration" errors as the parser desyncs.

## Fix

Remove the **early** duplicate `} // namespace` (the one after `eval_join_node`) so the anonymous namespace spans all the internal helpers (`validate_query_ast` … `execute_plan`), giving them internal linkage as clearly intended. After the change the file has a balanced 2-open / 2-close namespace structure.

`plan_query` and `execute_plan` are referenced only within this translation unit (verified: no other `.cpp`/`.cu`/header names them), so internalizing them changes nothing at link time.

## Verification

I don't have a CUDA toolkit in this environment, so I verified structurally rather than by an nvcc build:
- namespace opens/closes now balance (`namespace {` at lines 25, 155; `} // namespace` at 59, 960);
- total `{`/`}` counts match (200/200);
- the removed brace is exactly the token nvcc first rejected, and every follow-on error in the log is a recovery cascade from it.

This is one of two independent reasons CI is red; the parser-test targets also lack an `include/` path (fixed separately). Both are needed for a fully green `build` job.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJEwghgGPiVnTCMiYqtYt5)_