### PR TITLE
Fix build: put include/ on the search path for all targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,11 @@ enable_testing()
 
 set(CMAKE_CXX_STANDARD 17)
 
+# Make the public headers available to every target. Several test executables
+# compile tests/*.cpp together with src/expression.cpp without linking
+# warpdb_lib, so without this they fail to find "expression.hpp".
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
+
 find_package(CUDAToolkit REQUIRED)
 
 find_package(Arrow QUIET COMPONENTS cuda)


### PR DESCRIPTION
## Problem

Several test executables compile `tests/*.cpp` together with `src/expression.cpp` **without** linking `warpdb_lib` — and `warpdb_lib`'s `PUBLIC` include directory was the only thing exposing the headers. So those targets never found `include/` and failed in CI:

```
tests/query_parser_test.cpp:1:10: fatal error: expression.hpp: No such file or directory
tests/test_expression.cpp:1:10:  fatal error: expression.hpp: No such file or directory
src/expression.cpp:1:10:         fatal error: expression.hpp: No such file or directory
```

Affected: `expression_test`, `expression_tests`, `query_parser_test`, `parsing_error_tests`, `tokenizer_tests` (and the parser tests added in sibling PRs).

## Fix

Add a top-level `include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)` so every target can find the public headers. It's additive — targets that already set their own include path are unaffected.

## Notes

- I can't run `cmake` here (no CUDA toolkit for `find_package(CUDAToolkit REQUIRED)`), but the change directly resolves the exact `expression.hpp: No such file or directory` errors from the CI log by putting `include/` on the global search path.
- This is **one of two** independent reasons the `build` job is red. The other is a stray namespace brace in `warpdb.cpp` (#170). Both need to land for a fully green `build`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJEwghgGPiVnTCMiYqtYt5)_