### PR TITLE
Fix remaining build errors: expression_tests linkage and GPU test ColumnDesc construction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,10 +77,13 @@ add_executable(expression_test
 add_test(NAME expression_test COMMAND expression_test)
 
 
+# expression_tests exercises the CUDA JIT path (jit_compile_and_launch,
+# cudaMalloc/cudaMemcpy, and the skip-if-no-CUDA helper), so it must link the
+# full library rather than only src/expression.cpp.
 add_executable(expression_tests
     tests/expression_tests.cpp
-    src/expression.cpp
 )
+target_link_libraries(expression_tests PRIVATE warpdb_lib)
 
 add_test(NAME expression_tests COMMAND expression_tests)
 


### PR DESCRIPTION
Drives the `build` job the rest of the way to compiling+linking, on top of #170 (stray brace) and #171 (include path). Two distinct root causes, both pre-existing and only reachable now that the build gets past `warpdb.cpp`:

## 1. `expression_tests` failed to link

`tests/expression_tests.cpp` exercises the CUDA JIT path (`jit_compile_and_launch`, `cudaMalloc`/`cudaMemcpy`/`cudaFree`, `warpdb_skip_if_no_cuda` → `cudaGetDeviceCount`) but was registered to compile only `expression.cpp` with no CUDA libs:

```
undefined reference to `jit_compile_and_launch(...)' / `cudaMemcpy' / `cudaMalloc' / `cudaGetDeviceCount'
```

Fix: link it against `warpdb_lib` (parser + JIT + PUBLIC `CUDA::cudart`/`nvrtc`/`cuda_driver`), like every other GPU test, and drop the redundant `expression.cpp` source. I audited all 21 CUDA-using tests — this was the only misconfigured one.

## 2. GPU tests built `ColumnDesc` with the old shape

`jit_error_test`, `jit_arch_test`, `jit_cache_test`, `jit_where_zero_test` did:

```cpp
table.columns.push_back({"price", DataType::Float32, d_price, N});
```

`ColumnDesc` now holds a move-only `ColumnDevicePtr` (explicit `void*` ctor) plus a separate `string_data` buffer, so this aggregate-init no longer matches:

```
error: no matching function for call to 'std::vector<ColumnDesc>::push_back(<brace-enclosed initializer list>)'
```

Fix: add a `warpdb_make_device_column()` helper in `test_utils.hpp` (fills fields, takes ownership of the device pointer — matching the `.device_ptr.reset(...)` pattern already used by `jit_compile_log_test`/`optimizer_test`) and use it in the four tests. Those pointers were previously leaked, so taking ownership also frees them at `Table` destruction with no double-free.

## Verification

No CUDA toolkit here, so verified against the CI logs and the current header/struct definitions rather than an nvcc build:
- the link fix matches `warpdb_lib`'s existing PUBLIC CUDA linkage and the pattern of sibling GPU tests;
- the `ColumnDesc` helper mirrors how `src/csv_loader.cpp` and the already-correct `jit_compile_log_test`/`optimizer_test` construct columns.

The GPU-free `host-tests` job remains green. After this lands the `build` job should compile and link end-to-end; the subsequent `ctest`/Python steps run on a GPU-less runner and rely on the skip-if-no-CUDA guard.