### PR TITLE
Fix remaining build errors: GPU test ColumnDesc construction + optimizer_test JIT link

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -282,10 +282,13 @@ add_executable(jit_cache_test
 target_link_libraries(jit_cache_test PRIVATE CUDA::cudart CUDA::nvrtc CUDA::cuda_driver)
 add_test(NAME jit_cache_test COMMAND jit_cache_test)
 
+# optimizer.cpp calls jit_compile_and_launch (defined in jit.cu), so the JIT
+# translation unit must be part of this target to satisfy the reference.
 add_executable(optimizer_test
     tests/optimizer_test.cpp
     src/expression.cpp
     src/optimizer.cpp
+    src/jit.cu
 )
 target_link_libraries(optimizer_test PRIVATE CUDA::cudart CUDA::nvrtc CUDA::cuda_driver)
 add_test(NAME optimizer_test COMMAND optimizer_test)

--- a/tests/jit_arch_test.cpp
+++ b/tests/jit_arch_test.cpp
@@ -23,8 +23,8 @@ int main() {
 
     Table table;
     table.num_rows = 1;
-    table.columns.push_back({"price", DataType::Float32, d_price, 1});
-    table.columns.push_back({"quantity", DataType::Int32, d_quantity, 1});
+    table.columns.push_back(warpdb_make_device_column("price", DataType::Float32, d_price, 1));
+    table.columns.push_back(warpdb_make_device_column("quantity", DataType::Int32, d_quantity, 1));
 
     bool threw = false;
     try {

--- a/tests/jit_cache_test.cpp
+++ b/tests/jit_cache_test.cpp
@@ -28,8 +28,8 @@ int main() {
 
     Table table;
     table.num_rows = N;
-    table.columns.push_back({"price", DataType::Float32, d_price, N});
-    table.columns.push_back({"quantity", DataType::Int32, d_quantity, N});
+    table.columns.push_back(warpdb_make_device_column("price", DataType::Float32, d_price, N));
+    table.columns.push_back(warpdb_make_device_column("quantity", DataType::Int32, d_quantity, N));
 
     auto timed_run = [&](float *out_ptr) {
         auto start = std::chrono::steady_clock::now();

--- a/tests/jit_error_test.cpp
+++ b/tests/jit_error_test.cpp
@@ -12,8 +12,8 @@ int main() {
 
     Table table;
     table.num_rows = 1;
-    table.columns.push_back({"price", DataType::Float32, price, 1});
-    table.columns.push_back({"quantity", DataType::Int32, quantity, 1});
+    table.columns.push_back(warpdb_make_device_column("price", DataType::Float32, price, 1));
+    table.columns.push_back(warpdb_make_device_column("quantity", DataType::Int32, quantity, 1));
 
     bool threw = false;
     try {

--- a/tests/jit_where_zero_test.cpp
+++ b/tests/jit_where_zero_test.cpp
@@ -19,7 +19,7 @@ int main() {
 
     Table table;
     table.num_rows = N;
-    table.columns.push_back({"price", DataType::Float32, d_price, N});
+    table.columns.push_back(warpdb_make_device_column("price", DataType::Float32, d_price, N));
 
     jit_compile_and_launch("price * 2.0f", "price > 2.0f", table, d_output);
 

--- a/tests/test_utils.hpp
+++ b/tests/test_utils.hpp
@@ -1,6 +1,10 @@
 #pragma once
 #include <cuda_runtime.h>
 #include <cstdio>
+#include <string>
+#include <utility>
+
+#include "csv_loader.hpp"
 
 // Shared helpers for the test suite.
 //
@@ -22,4 +26,19 @@ inline bool warpdb_skip_if_no_cuda(const char *test_name) {
     return true;
   }
   return false;
+}
+
+// Build a device-resident numeric column for tests. ColumnDesc holds a
+// move-only ColumnDevicePtr (with an explicit void* constructor) plus a
+// separate string_data buffer, so it can't be aggregate-initialized from a raw
+// pointer. This helper takes ownership of `device_ptr` (freed when the column
+// is destroyed).
+inline ColumnDesc warpdb_make_device_column(std::string name, DataType type,
+                                            void *device_ptr, int length) {
+  ColumnDesc col;
+  col.name = std::move(name);
+  col.type = type;
+  col.device_ptr = ColumnDevicePtr(device_ptr);
+  col.length = length;
+  return col;
 }


### PR DESCRIPTION
Follow-up to #172. That PR merged with only the `expression_tests` link fix; this second commit (the `ColumnDesc` test fix) landed on the branch after the merge, so it never reached `main`. Re-submitting it as a fresh PR off current `main`.

## Problem

With `main` now building past `warpdb.cpp`, the next `build` failure is a compile error in four GPU tests:

```
tests/jit_error_test.cpp:15: error: no matching function for call to
  'std::vector<ColumnDesc>::push_back(<brace-enclosed initializer list>)'
```

`jit_error_test`, `jit_arch_test`, `jit_cache_test`, and `jit_where_zero_test` build a device `Table` by aggregate-initializing `ColumnDesc` from a raw pointer:

```cpp
table.columns.push_back({"price", DataType::Float32, d_price, N});
```

`ColumnDesc` now holds a move-only `ColumnDevicePtr` (explicit `void*` ctor) plus a separate `string_data` buffer, so the brace-init no longer matches its element types/arity. These tests never compiled while the build was broken upstream; now that `main` builds, they surface.

## Fix

Add a `warpdb_make_device_column()` helper in `test_utils.hpp` that fills the fields and takes ownership of the device pointer — matching the `.device_ptr.reset(...)` pattern already used by `jit_compile_log_test` and `optimizer_test` — and use it in the four tests. Those pointers were previously leaked, so taking ownership also frees them at `Table` destruction, with no double-free (the tests never freed them).

## Verification

No CUDA toolkit here, so verified against the current struct definitions and the already-correct sibling tests rather than an nvcc build. The change is test-only; the GPU-free `host-tests` job is unaffected.

This should clear the next `build` error after #172. If `ctest`/Python steps surface anything further on the GPU-less runner, I'll continue.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJEwghgGPiVnTCMiYqtYt5)_