### PR TITLE
Fix GPU test compilation against the current ColumnDesc

### DIFF
--- a/tests/jit_arch_test.cpp
+++ b/tests/jit_arch_test.cpp
@@ -23,8 +23,8 @@ int main() {
 
     Table table;
     table.num_rows = 1;
-    table.columns.push_back({"price", DataType::Float32, d_price, 1});
-    table.columns.push_back({"quantity", DataType::Int32, d_quantity, 1});
+    table.columns.push_back(warpdb_make_device_column("price", DataType::Float32, d_price, 1));
+    table.columns.push_back(warpdb_make_device_column("quantity", DataType::Int32, d_quantity, 1));
 
     bool threw = false;
     try {

--- a/tests/jit_cache_test.cpp
+++ b/tests/jit_cache_test.cpp
@@ -28,8 +28,8 @@ int main() {
 
     Table table;
     table.num_rows = N;
-    table.columns.push_back({"price", DataType::Float32, d_price, N});
-    table.columns.push_back({"quantity", DataType::Int32, d_quantity, N});
+    table.columns.push_back(warpdb_make_device_column("price", DataType::Float32, d_price, N));
+    table.columns.push_back(warpdb_make_device_column("quantity", DataType::Int32, d_quantity, N));
 
     auto timed_run = [&](float *out_ptr) {
         auto start = std::chrono::steady_clock::now();

--- a/tests/jit_error_test.cpp
+++ b/tests/jit_error_test.cpp
@@ -12,8 +12,8 @@ int main() {
 
     Table table;
     table.num_rows = 1;
-    table.columns.push_back({"price", DataType::Float32, price, 1});
-    table.columns.push_back({"quantity", DataType::Int32, quantity, 1});
+    table.columns.push_back(warpdb_make_device_column("price", DataType::Float32, price, 1));
+    table.columns.push_back(warpdb_make_device_column("quantity", DataType::Int32, quantity, 1));
 
     bool threw = false;
     try {

--- a/tests/jit_where_zero_test.cpp
+++ b/tests/jit_where_zero_test.cpp
@@ -19,7 +19,7 @@ int main() {
 
     Table table;
     table.num_rows = N;
-    table.columns.push_back({"price", DataType::Float32, d_price, N});
+    table.columns.push_back(warpdb_make_device_column("price", DataType::Float32, d_price, N));
 
     jit_compile_and_launch("price * 2.0f", "price > 2.0f", table, d_output);
 

--- a/tests/test_utils.hpp
+++ b/tests/test_utils.hpp
@@ -1,6 +1,10 @@
 #pragma once
 #include <cuda_runtime.h>
 #include <cstdio>
+#include <string>
+#include <utility>
+
+#include "csv_loader.hpp"
 
 // Shared helpers for the test suite.
 //
@@ -22,4 +26,19 @@ inline bool warpdb_skip_if_no_cuda(const char *test_name) {
     return true;
   }
   return false;
+}
+
+// Build a device-resident numeric column for tests. ColumnDesc holds a
+// move-only ColumnDevicePtr (with an explicit void* constructor) plus a
+// separate string_data buffer, so it can't be aggregate-initialized from a raw
+// pointer. This helper takes ownership of `device_ptr` (freed when the column
+// is destroyed).
+inline ColumnDesc warpdb_make_device_column(std::string name, DataType type,
+                                            void *device_ptr, int length) {
+  ColumnDesc col;
+  col.name = std::move(name);
+  col.type = type;
+  col.device_ptr = ColumnDevicePtr(device_ptr);
+  col.length = length;
+  return col;
 }


### PR DESCRIPTION
jit_error_test, jit_arch_test, jit_cache_test and jit_where_zero_test built a device Table by aggregate-initializing ColumnDesc from a raw pointer:

    table.columns.push_back({"price", DataType::Float32, d_price, N});

That no longer compiles: ColumnDesc now holds a move-only ColumnDevicePtr (with an explicit void* constructor) plus a separate string_data buffer, so the brace-init has the wrong element types and arity ("no matching function for call to vector<ColumnDesc>::push_back"). These tests never compiled in CI because the build was broken upstream; with the build fixed they surface.

Add a warpdb_make_device_column() helper in test_utils.hpp that fills in the fields and takes ownership of the device pointer (matching the existing .device_ptr.reset(...) pattern already used by jit_compile_log_test and optimizer_test), and use it in the four tests. The column pointers were previously leaked, so taking ownership also frees them at Table destruction without any double-free.


Claude-Session: https://claude.ai/code/session_01KJEwghgGPiVnTCMiYqtYt5