### PR TITLE
Fix build: disable nlohmann/json's bundled unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,12 @@ find_package(CUDAToolkit REQUIRED)
 find_package(Arrow QUIET COMPONENTS cuda)
 
 include(FetchContent)
+# Do not build nlohmann/json's bundled unit tests. v3.2.0 vendors an old Catch
+# (test/thirdparty/catch/catch.hpp) that no longer compiles on modern glibc,
+# where SIGSTKSZ is not a compile-time constant ("size of array 'altStackMem'
+# is not an integral constant-expression"). We only consume the library
+# headers, so its test suite must not be part of our build.
+set(JSON_BuildTests OFF CACHE INTERNAL "")
 FetchContent_Declare(
   nlohmann_json
   GIT_REPOSITORY https://github.com/nlohmann/json.git


### PR DESCRIPTION
## Problem

With WarpDB itself now compiling and linking, the `build` job reaches the next failure — in the **nlohmann/json dependency**, not our code. `FetchContent_MakeAvailable(nlohmann_json)` (v3.2.0) was also configuring the library's own test suite, whose vendored Catch header fails on the runner's toolchain:

```
build/_deps/nlohmann_json-src/test/thirdparty/catch/catch.hpp:6543:33:
  error: size of array 'altStackMem' is not an integral constant-expression
gmake[2]: *** [.../catch_main.dir/src/unit.cpp.o] Error 1
```

`SIGSTKSZ` became a runtime value in glibc 2.34+, so the old bundled Catch's `altStackMem[SIGSTKSZ]` is no longer a constant-sized array. WarpDB only consumes the json headers, so its test suite shouldn't be in our build at all.

## Fix

Set `JSON_BuildTests OFF` (cache) before `FetchContent_MakeAvailable`, so only the library target is configured.

The **v3.2.0 pin is unchanged** — `setup.py` and the README still match it (and the code deliberately avoids APIs newer than v3.2.0). This only stops building the dependency's tests.

## Verification

No CUDA toolkit here to run the full configure, but the change is a well-known, targeted fix: it removes the `catch_main`/`unit` test targets (the exact ones in the error) from the generated build while leaving `nlohmann_json::nlohmann_json` intact. `host-tests` is unaffected and green.

This is the next error after the merged build fixes (#170–#173). If the subsequent `ctest`/Python steps surface anything on the GPU-less runner, I'll keep going.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJEwghgGPiVnTCMiYqtYt5)_