### PR TITLE
Extend the GPU-free host test lane to the newest parser tests

### DIFF
--- a/tests/run_host_tests.sh
+++ b/tests/run_host_tests.sh
@@ -23,6 +23,9 @@ host_tests=(
   tests/query_parser_test.cpp
   tests/equals_operator_test.cpp
   tests/having_aggregate_test.cpp
+  tests/not_equal_operator_test.cpp
+  tests/select_star_test.cpp
+  tests/eval_logical_ops_test.cpp
 )
 
 tmp="$(mktemp -d)"
@@ -31,7 +34,10 @@ trap 'rm -rf "$tmp"' EXIT
 fail=0
 for src in "${host_tests[@]}"; do
   name="$(basename "$src" .cpp)"
-  if ! "$CXX" "-std=$STD" -Iinclude "$src" src/expression.cpp -o "$tmp/$name" 2>"$tmp/$name.log"; then
+  # tests/stubs provides lightweight CUDA headers for host-only tests that
+  # transitively include <cuda_runtime.h> (e.g. via eval_helpers.hpp); parser
+  # tests that don't include it are unaffected.
+  if ! "$CXX" "-std=$STD" -Iinclude -Itests/stubs "$src" src/expression.cpp -o "$tmp/$name" 2>"$tmp/$name.log"; then
     echo "FAIL  $name (compile)"
     cat "$tmp/$name.log"
     fail=1


### PR DESCRIPTION
## What

The GPU-free `host-tests` lane (`tests/run_host_tests.sh`) had fallen behind the parser tests added since it was introduced. This adds the three newest parser-only tests to it:

- `not_equal_operator_test` (`<>` operator)
- `select_star_test` (`SELECT *` parsing)
- `eval_logical_ops_test` (host-side AND/OR evaluation)

`eval_logical_ops_test` includes `eval_helpers.hpp`, which transitively pulls in `<cuda_runtime.h>`, so the compile line now also passes `-Itests/stubs` (the lightweight CUDA shim). Pure-parser tests don't include it and are unaffected.

## Why

These three landed in earlier PRs but were only exercised by the full GPU-backed `ctest` build. Now the fast, no-CUDA lane catches regressions in them too — including the AND/OR host-eval correctness fix, which is exactly the kind of silent bug this lane exists to guard.

## Testing

```
$ ./tests/run_host_tests.sh
...
PASS  not_equal_operator_test -- not-equal operator test passed
PASS  select_star_test -- select star test passed
PASS  eval_logical_ops_test -- eval logical ops test passed
Host-only test suite passed (10 tests)
```

Test-tooling only; no library or CI-workflow changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJEwghgGPiVnTCMiYqtYt5)_