### PR TITLE
Fix wheel build: compile warpdb.cpp with nvcc in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,11 @@ from setuptools import setup
 from pybind11.setup_helpers import Pybind11Extension, build_ext
 
 
+# .cpp sources that use Thrust device execution policies (thrust::device) and
+# therefore must be compiled by nvcc, not the host C++ compiler. Compiling them
+# with gcc triggers Thrust's "unimplemented for this system" static assertion.
+CUDA_CPP_SOURCES = {'warpdb.cpp'}
+
 NLOHMANN_JSON_VERSION = 'v3.2.0'
 NLOHMANN_JSON_URLS = [
     f'https://raw.githubusercontent.com/nlohmann/json/{NLOHMANN_JSON_VERSION}/single_include/nlohmann/json.hpp',
@@ -56,7 +61,10 @@ class WarpDBBuildExt(build_ext):
         super_compile = self.compiler._compile
 
         def _compile(obj, src, ext, cc_args, extra_postargs, pp_opts):
-            is_cuda = os.path.splitext(src)[1] == '.cu'
+            src_ext = os.path.splitext(src)[1]
+            # .cu is CUDA; a few .cpp sources also require nvcc (see
+            # CUDA_CPP_SOURCES) because they use Thrust device execution.
+            compile_as_cuda = src_ext == '.cu' or os.path.basename(src) in CUDA_CPP_SOURCES
 
             if isinstance(extra_postargs, dict):
                 cxx_postargs = extra_postargs.get('cxx', [])
@@ -66,9 +74,14 @@ class WarpDBBuildExt(build_ext):
                 nvcc_postargs = extra_postargs
 
             try:
-                if is_cuda:
+                if compile_as_cuda:
                     self.compiler.set_executable('compiler_so', os.environ.get('NVCC', 'nvcc'))
                     postargs = ['-std=c++17', *nvcc_postargs]
+                    if src_ext != '.cu':
+                        # nvcc infers language from the extension; force CUDA for
+                        # .cpp sources. '-x cu' must precede the input file, so
+                        # prepend it to cc_args (postargs come after the source).
+                        cc_args = ['-x', 'cu', *cc_args]
                 else:
                     postargs = cxx_postargs
 


### PR DESCRIPTION
## Progress

With #170–#175 merged, the CMake **`Build` step now passes** — the failure has moved to the next CI step, `Build Python wheel`:

```
thrust/system/detail/generic/for_each.h:47:3: error: static assertion failed:
  unimplemented for this system
  ...
  src/warpdb.cpp:329:30:   required from here
ERROR: Failed building wheel for warpdb
```

## Cause

`src/warpdb.cpp` is the **only** source that uses a Thrust device execution policy (`thrust::device`), so it must be compiled by `nvcc` — which is exactly what the CMake build already does:

```cmake
set_source_files_properties(src/warpdb.cpp PROPERTIES LANGUAGE CUDA)
```

But `setup.py`'s compile hook only routed `.cu` files to `nvcc`, so `warpdb.cpp` went to `gcc` and tripped Thrust's device-backend static assertion.

## Fix

Route the `.cpp` sources in a new `CUDA_CPP_SOURCES` set (currently just `warpdb.cpp`) through `nvcc`, prepending `-x cu` **before** the input file (postargs come after the source on the command line, so `-x cu` there wouldn't apply). All other `.cpp` sources are pure host code and still use the host compiler.

## Verification

No CUDA toolkit here, so I verified what I can: `setup.py` parses cleanly (`ast.parse`), the change mirrors the CMake `LANGUAGE CUDA` treatment of the same file, and `warpdb.cpp` is confirmed to be the only thrust-using `.cpp` (`grep -l 'thrust::' src/*.cpp`). If the `nvcc`-vs-setuptools host-flag handling surfaces anything further on the runner, I'll iterate.

This is the next step after the CMake build fixes; `host-tests` remains green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJEwghgGPiVnTCMiYqtYt5)_