### PR TITLE
Fix load_csv_chunk to report end-of-input on a full final chunk

### DIFF
--- a/src/csv_loader.cpp
+++ b/src/csv_loader.cpp
@@ -489,6 +489,15 @@ HostTable load_csv_chunk(std::istream &stream, int max_rows, bool &finished,
     ++count;
   }
 
+  // The loop above stops as soon as the chunk is full (count == max_rows)
+  // without trying to read further, so it never observes end-of-input when the
+  // remaining rows exactly fill the final chunk. Honor the documented contract
+  // -- "finished is set to true when no more rows are available" -- by peeking
+  // for trailing data, so callers (and tests) don't require an extra empty read.
+  if (!finished && stream.peek() == std::char_traits<char>::eof()) {
+    finished = true;
+  }
+
   if (rows.empty()) {
     finished = finished || stream.eof();
     if (stream.fail() && !stream.eof()) {


### PR DESCRIPTION
## Problem

Now that CI reaches `ctest`, `csv_loader_chunk_test` and `csv_loader_chunk_mixed_types_test` fail:

```
csv_loader_chunk_test.cpp:38: int main(): Assertion `finished' failed.
```

`load_csv_chunk` reads until the chunk is full (`count == max_rows`) and then stops **without another read**, so when the remaining rows exactly fill the last chunk it never observes end-of-input and leaves `finished == false`. That violates the documented contract —

> `finished` will be set to true when no more rows are available

— and forced streaming callers to do an extra read that returns an empty table.

## Fix

After the read loop, peek the stream and set `finished = true` when there's no trailing data.

## Verification

`csv_loader.cpp` is host code, so I compiled and ran the affected tests locally against the CUDA stub headers:

```
[csv_loader_chunk_test] CSV chunk test passed
[csv_loader_chunk_mixed_types_test] CSV chunk mixed types test passed
```

Both fail before this change and pass after.

## Context

This is 2 of 8 `ctest` failures the (now-reached) test step surfaced. The other 6: five are a test-harness working-directory issue (tests open `data/*` relative to CWD; separate PR incoming), and one (`csv_loader_chunk_error_test`) asserts pre-string-column semantics that the current type inference deliberately no longer has — I'll raise that separately since it needs a semantics decision.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJEwghgGPiVnTCMiYqtYt5)_