### PR TITLE
Fix ctest failures: copy data/ into the build tree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,11 @@ set(CMAKE_CXX_STANDARD 17)
 # warpdb_lib, so without this they fail to find "expression.hpp".
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 
+# ctest runs from the build directory, but several loader tests open data files
+# by relative path (e.g. "data/numeric_valid.csv"). Copy the data directory into
+# the build tree at configure time so those paths resolve.
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/data DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+
 find_package(CUDAToolkit REQUIRED)
 
 find_package(Arrow QUIET COMPONENTS cuda)


### PR DESCRIPTION
## Problem

With CI now reaching `ctest`, five loader tests abort because they open fixture files by relative path while ctest runs them from the **build** directory:

```
Failed to open file: data/numeric_valid.csv
what():  Unable to open file
```

Affected: `csv_loader_error_test`, `csv_loader_row_length_test`, `json_loader_permissive_test`, `json_loader_schema_inference_test`, `csv_from_chars_test` (all open `data/*.csv` / `data/*.json`).

## Fix

Copy the `data/` directory into the build tree at configure time:

```cmake
file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/data DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
```

so the relative paths resolve when tests run from `build/`. One line, covers all five (and any future data-driven test).

## Verification

No CUDA toolkit here to run `cmake`, but this is a standard configure-time copy and the fixture files it references already exist in `data/` (confirmed). The five failing tests each open a path under `data/` that will now exist in the build dir.

## Context

This is 5 of the 8 `ctest` failures. #178 fixes 2 more (the `load_csv_chunk` EOF bug). The last one, `csv_loader_chunk_error_test`, asserts pre-string-column semantics the current type inference deliberately dropped — flagged separately for a decision.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJEwghgGPiVnTCMiYqtYt5)_